### PR TITLE
added more and optional colors to color picker

### DIFF
--- a/css/calendarlist.css
+++ b/css/calendarlist.css
@@ -207,7 +207,7 @@
 /* ColorPicker overrides. */
 .colorpicker {
   display: block;
-  height: 30px;
+  height: 18px;
 }
 .colorpicker .colorpicker-list {
   display: block;
@@ -216,7 +216,7 @@
 }
 .colorpicker .colorpicker-list li {
   height: 100%;
-  width: 29px !important;
+  width: 18px !important;
   float: left;
 }
 .colorpicker .colorpicker-list li.selected {

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -994,7 +994,7 @@ app.controller('SettingsController', ['$scope', '$rootScope', 'Restangular', 'Ca
 app.controller('SubscriptionController', ['$scope', '$rootScope', '$window', 'SubscriptionModel', 'CalendarModel', 'Restangular',
 	function ($scope, $rootScope, $window, SubscriptionModel, CalendarModel, Restangular) {
 		'use strict';
-		
+
 		$scope.subscriptions = SubscriptionModel.getAll();
 		var subscriptionResource = Restangular.all('subscriptions');
 
@@ -1035,14 +1035,253 @@ app.controller('SubscriptionController', ['$scope', '$rootScope', '$window', 'Su
 app.directive('colorpicker', function() {
   'use strict';
     var listofcolours =  [
-        '#21213D',
-        '#253151',
-        '#9C909D',
-        '#3A3B3D',
-        '#FF7A66',
-        '#009CFC',
-        '#F1DB50',
-        '#CC317C'
+//			'#190000', // Red              dark 90%
+//			'#190C00', // Orange           dark 90%
+//			'#191900', // Yellow           dark 90%
+//			'#0C1900', // Chartreuse Green dark 90%
+//			'#001900', // Green            dark 90%
+//			'#00190C', // Spring Green     dark 90%
+//			'#001919', // Cyan             dark 90%
+//			'#000C19', // Azure Blue       dark 90%
+//			'#000019', // Blue             dark 90%
+//			'#0C0019', // Violet           dark 90%
+//			'#190019', // Magenta          dark 90%
+//			'#19000C', // Rose             dark 90%
+//			'#141414', // Gray 20
+//			'#320000', // Red              dark 80%
+//			'#321900', // Orange           dark 80%
+//			'#323200', // Yellow           dark 80%
+//			'#193200', // Chartreuse Green dark 80%
+//			'#003200', // Green            dark 80%
+//			'#003219', // Spring Green     dark 80%
+//			'#003232', // Cyan             dark 80%
+//			'#001932', // Azure Blue       dark 80%
+//			'#000032', // Blue             dark 80%
+//			'#190032', // Violet           dark 80%
+//			'#320032', // Magenta          dark 80%
+//			'#320019', // Rose             dark 80%
+//			'#202020', // Gray 32
+//			'#4C0000', // Red              dark 70%
+//			'#4C2600', // Orange           dark 70%
+//			'#4C4C00', // Yellow           dark 70%
+//			'#264C00', // Chartreuse Green dark 70%
+//			'#004C00', // Green            dark 70%
+//			'#004C26', // Spring Green     dark 70%
+//			'#004C4C', // Cyan             dark 70%
+//			'#00264C', // Azure Blue       dark 70%
+//			'#00004C', // Blue             dark 70%
+//			'#26004C', // Violet           dark 70%
+//			'#4C004C', // Magenta          dark 70%
+//			'#4C0026', // Rose             dark 70%
+//			'#2C2C2C', // Gray 44
+			'#660000', // Red              dark 60%
+			'#663200', // Orange           dark 60%
+			'#666600', // Yellow           dark 60%
+			'#326600', // Chartreuse Green dark 60%
+			'#006600', // Green            dark 60%
+			'#006632', // Spring Green     dark 60%
+			'#006666', // Cyan             dark 60%
+			'#003266', // Azure Blue       dark 60%
+			'#000066', // Blue             dark 60%
+			'#320066', // Violet           dark 60%
+			'#660066', // Magenta          dark 60%
+			'#660032', // Rose             dark 60%
+			'#383838', // Gray 56
+//			'#7F0000', // Red              dark 50%
+//			'#7F3F00', // Orange           dark 50%
+//			'#7F7F00', // Yellow           dark 50%
+//			'#3F7F00', // Chartreuse Green dark 50%
+//			'#007F00', // Green            dark 50%
+//			'#007F3F', // Spring Green     dark 50%
+//			'#007F7F', // Cyan             dark 50%
+//			'#003F7F', // Azure Blue       dark 50%
+//			'#00007F', // Blue             dark 50%
+//			'#3F007F', // Violet           dark 50%
+//			'#7F007F', // Magenta          dark 50%
+//			'#7F003F', // Rose             dark 50%
+//			'#444444', // Gray 68
+			'#990000', // Red              dark 40%
+			'#994C00', // Orange           dark 40%
+			'#999900', // Yellow           dark 40%
+			'#4C9900', // Chartreuse Green dark 40%
+			'#009900', // Green            dark 40%
+			'#00994C', // Spring Green     dark 40%
+			'#009999', // Cyan             dark 40%
+			'#004C99', // Azure Blue       dark 40%
+			'#000099', // Blue             dark 40%
+			'#4C0099', // Violet           dark 40%
+			'#990099', // Magenta          dark 40%
+			'#99004C', // Rose             dark 40%
+			'#505050', // Gray 80
+//			'#B20000', // Red              dark 30%
+//			'#B25800', // Orange           dark 30%
+//			'#B2B200', // Yellow           dark 30%
+//			'#58B200', // Chartreuse Green dark 30%
+//			'#00B200', // Green            dark 30%
+//			'#00B258', // Spring Green     dark 30%
+//			'#00B2B2', // Cyan             dark 30%
+//			'#0058B2', // Azure Blue       dark 30%
+//			'#0000B2', // Blue             dark 30%
+//			'#5800B2', // Violet           dark 30%
+//			'#B200B2', // Magenta          dark 30%
+//			'#B20058', // Rose             dark 30%
+//			'#5C5C5C', // Gray 92
+			'#CC0000', // Red              dark 20%
+			'#CC6500', // Orange           dark 20%
+			'#CCCC00', // Yellow           dark 20%
+			'#65CC00', // Chartreuse Green dark 20%
+			'#00CC00', // Green            dark 20%
+			'#00CC65', // Spring Green     dark 20%
+			'#00CCCC', // Cyan             dark 20%
+			'#0065CC', // Azure Blue       dark 20%
+			'#0000CC', // Blue             dark 20%
+			'#6500CC', // Violet           dark 20%
+			'#CC00CC', // Magenta          dark 20%
+			'#CC0065', // Rose             dark 20%
+			'#686868', // Gray 104
+//			'#E50000', // Red              dark 10%
+//			'#E57200', // Orange           dark 10%
+//			'#E5E500', // Yellow           dark 10%
+//			'#72E500', // Chartreuse Green dark 10%
+//			'#00E500', // Green            dark 10%
+//			'#00E572', // Spring Green     dark 10%
+//			'#00E5E5', // Cyan             dark 10%
+//			'#0072E5', // Azure Blue       dark 10%
+//			'#0000E5', // Blue             dark 10%
+//			'#7200E5', // Violet           dark 10%
+//			'#E500E5', // Magenta          dark 10%
+//			'#E50072', // Rose             dark 10%
+//			'#747474', // Gray 116
+			'#FF0000', // Red
+			'#FF7F00', // Orange
+			'#FFFF00', // Yellow
+			'#7FFF00', // Chartreuse Green
+			'#00FF00', // Green
+			'#00FF7F', // Spring Green
+			'#00FFFF', // Cyan
+			'#007FFF', // Azure Blue
+			'#0000FF', // Blue
+			'#7F00FF', // Violet
+			'#FF00FF', // Magenta
+			'#FF007F', // Rose
+			'#808080', // Gray 128
+//			'#FF1919', // Red              tint 10%
+//			'#FF8B19', // Orange           tint 10%
+//			'#FFFF19', // Yellow           tint 10%
+//			'#8BFF19', // Chartreuse Green tint 10%
+//			'#19FF19', // Green            tint 10%
+//			'#19FF8B', // Spring Green     tint 10%
+//			'#19FFFF', // Cyan             tint 10%
+//			'#198BFF', // Azure Blue       tint 10%
+//			'#1919FF', // Blue             tint 10%
+//			'#8B19FF', // Violet           tint 10%
+//			'#FF19FF', // Magenta          tint 10%
+//			'#FF198B', // Rose             tint 10%
+//			'#8C8C8C', // Gray 140
+			'#FF3333', // Red              tint 20%
+			'#FF9833', // Orange           tint 20%
+			'#FFFF33', // Yellow           tint 20%
+			'#98FF33', // Chartreuse Green tint 20%
+			'#33FF33', // Green            tint 20%
+			'#33FF98', // Spring Green     tint 20%
+			'#33FFFF', // Cyan             tint 20%
+			'#3398FF', // Azure Blue       tint 20%
+			'#3333FF', // Blue             tint 20%
+			'#9833FF', // Violet           tint 20%
+			'#FF33FF', // Magenta          tint 20%
+			'#FF3398', // Rose             tint 20%
+			'#989898', // Gray 152
+//			'#FF4C4C', // Red              tint 30%
+//			'#FFA54C', // Orange           tint 30%
+//			'#FFFF4C', // Yellow           tint 30%
+//			'#A5FF4C', // Chartreuse Green tint 30%
+//			'#4CFF4C', // Green            tint 30%
+//			'#4CFFA5', // Spring Green     tint 30%
+//			'#4CFFFF', // Cyan             tint 30%
+//			'#4CA5FF', // Azure Blue       tint 30%
+//			'#4C4CFF', // Blue             tint 30%
+//			'#A54CFF', // Violet           tint 30%
+//			'#FF4CFF', // Magenta          tint 30%
+//			'#FF4CA5', // Rose             tint 30%
+//			'#A4A4A4', // Gray 164
+			'#FF6666', // Red              tint 40%
+			'#FFB266', // Orange           tint 40%
+			'#FFFF66', // Yellow           tint 40%
+			'#B2FF66', // Chartreuse Green tint 40%
+			'#66FF66', // Green            tint 40%
+			'#66FFB2', // Spring Green     tint 40%
+			'#66FFFF', // Cyan             tint 40%
+			'#66B2FF', // Azure Blue       tint 40%
+			'#6666FF', // Blue             tint 40%
+			'#B266FF', // Violet           tint 40%
+			'#FF66FF', // Magenta          tint 40%
+			'#FF66B2', // Rose             tint 40%
+			'#B0B0B0', // Gray 176
+//			'#FF7F7F', // Red              tint 50%
+//			'#FFBF7F', // Orange           tint 50%
+//			'#FFFF7F', // Yellow           tint 50%
+//			'#BFFF7F', // Chartreuse Green tint 50%
+//			'#7FFF7F', // Green            tint 50%
+//			'#7FFFBF', // Spring Green     tint 50%
+//			'#7FFFFF', // Cyan             tint 50%
+//			'#7FBFFF', // Azure Blue       tint 50%
+//			'#7F7FFF', // Blue             tint 50%
+//			'#BF7FFF', // Violet           tint 50%
+//			'#FF7FFF', // Magenta          tint 50%
+//			'#FF7FBF', // Rose             tint 50%
+//			'#BCBCBC', // Gray 188
+			'#FF9999', // Red              tint 60%
+			'#FFCB99', // Orange           tint 60%
+			'#FFFF99', // Yellow           tint 60%
+			'#CBFF99', // Chartreuse Green tint 60%
+			'#99FF99', // Green            tint 60%
+			'#99FFCB', // Spring Green     tint 60%
+			'#99FFFF', // Cyan             tint 60%
+			'#99CBFF', // Azure Blue       tint 60%
+			'#9999FF', // Blue             tint 60%
+			'#CB99FF', // Violet           tint 60%
+			'#FF99FF', // Magenta          tint 60%
+			'#FF99CB', // Rose             tint 60%
+			'#C8C8C8', // Gray 200
+//			'#FFB2B2', // Red              tint 70%
+//			'#FFD8B2', // Orange           tint 70%
+//			'#FFFFB2', // Yellow           tint 70%
+//			'#D8FFB2', // Chartreuse Green tint 70%
+//			'#B2FFB2', // Green            tint 70%
+//			'#B2FFD8', // Spring Green     tint 70%
+//			'#B2FFFF', // Cyan             tint 70%
+//			'#B2D8FF', // Azure Blue       tint 70%
+//			'#B2B2FF', // Blue             tint 70%
+//			'#D8B2FF', // Violet           tint 70%
+//			'#FFB2FF', // Magenta          tint 70%
+//			'#FFB2D8', // Rose             tint 70%
+//			'#D4D4D4', // Gray 212
+//			'#FFCCCC', // Red              tint 80%
+//			'#FFE5CC', // Orange           tint 80%
+//			'#FFFFCC', // Yellow           tint 80%
+//			'#E5FFCC', // Chartreuse Green tint 80%
+//			'#CCFFCC', // Green            tint 80%
+//			'#CCFFE5', // Spring Green     tint 80%
+//			'#CCFFFF', // Cyan             tint 80%
+//			'#CCE5FF', // Azure Blue       tint 80%
+//			'#CCCCFF', // Blue             tint 80%
+//			'#E5CCFF', // Violet           tint 80%
+//			'#FFCCFF', // Magenta          tint 80%
+//			'#FFCCE5', // Rose             tint 80%
+//			'#E0E0E0', // Gray 224
+//			'#FFE5E5', // Red              tint 90%
+//			'#FFF2E5', // Orange           tint 90%
+//			'#FFFFE5', // Yellow           tint 90%
+//			'#F2FFE5', // Chartreuse Green tint 90%
+//			'#E5FFE5', // Green            tint 90%
+//			'#E5FFF2', // Spring Green     tint 90%
+//			'#E5FFFF', // Cyan             tint 90%
+//			'#E5F2FF', // Azure Blue       tint 90%
+//			'#E5E5FF', // Blue             tint 90%
+//			'#F2E5FF', // Violet           tint 90%
+//			'#FFE5FF', // Magenta          tint 90%
+//			'#FFE5F2', // Rose             tint 90%
+//			'#ECECEC', // Gray 236
     ];
     return {
         scope: {
@@ -1233,7 +1472,7 @@ app.filter('simpleReminderDescription', function() {
 app.filter('subscriptionFilter',
 	[ function () {
 		'use strict';
-		
+
 		var subscriptionfilter = function (item) {
 			var filter = [];
 			if (item.length > 0) {
@@ -1496,7 +1735,7 @@ app.factory('eventEditorHelper', function () {
 		-1 * 60 * 60,
 		-1 * 2 * 60 * 60
 	];
-	
+
 	/**
 	 * prepare alarm
 	 */
@@ -2402,7 +2641,7 @@ app.factory('TimezoneModel', function () {
 
 app.factory('UploadModel', ["$rootScope", function ($rootScope) {
 	'use strict';
-	
+
 	var _files = [];
 	return {
 		add: function (file) {


### PR DESCRIPTION
Based on the discussion in [issue #460 of the original calendar app](https://github.com/owncloud/calendar/issues/460) more colors are defined.
Basis is a ColorWheel with 12 segments + Gray. Starting from that pure colors, darker and less saturated variants are generated in steps of 10%.

As not everybody may like that much colors, most of them are commented out. But as they are provided with the source, it is easy to enable them just by removing the comment.
![colorpicker12_20b_rework](https://cloud.githubusercontent.com/assets/5821779/11407110/fd6b5368-93b0-11e5-95de-bf7a3b03876a.png)
There is still a problem in the existing layout between 'new calendar' and 'modify calendar', as the modify has a scroll bar and looks scrambled. When somebody fixes that, it could be considered to force a colorpicker layout with 13 colors in one row. Any hints how to do that would be appreciated.
Comments are welcome!
