### PR TITLE
Refine CSS targeting of today's background color

### DIFF
--- a/js/app/controllers/calcontroller.js
+++ b/js/app/controllers/calcontroller.js
@@ -179,7 +179,7 @@ app.controller('CalController', ['$scope', '$rootScope', '$window', 'CalendarSer
 					if (newView === 'agendaDay') {
 						angular.element('td.fc-state-highlight').css('background-color', '#ffffff');
 					} else {
-						angular.element('td.fc-state-highlight').css('background-color', '#ffc');
+						angular.element('.fc-bg td.fc-state-highlight').css('background-color', '#ffc');
 					}
 					if (newView ==='agendaWeek') {
 						element.fullCalendar('option', 'aspectRatio', 0.1);

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -199,7 +199,7 @@ app.controller('CalController', ['$scope', '$rootScope', '$window', 'CalendarSer
 					if (newView === 'agendaDay') {
 						angular.element('td.fc-state-highlight').css('background-color', '#ffffff');
 					} else {
-						angular.element('td.fc-state-highlight').css('background-color', '#ffc');
+						angular.element('.fc-bg td.fc-state-highlight').css('background-color', '#ffc');
 					}
 					if (newView ==='agendaWeek') {
 						element.fullCalendar('option', 'aspectRatio', 0.1);


### PR DESCRIPTION
The old CSS selector for setting the background color of the highlighted day (today) also affected `<td>` elements within `.fc-content-skeleton`.

The FullCalendar CSS gives `.fc-content-skeleton` a transparent background and border, so that the underlying background and border of `.fc-bg` are shown.

Overriding of the `background-color` of `.fc-content-skeleton` by ownCloud inline CSS can, under certain circumstances, lead to that background color extending under the (transparent) border of
`.fc-content-skeleton`, thereby overlapping the border of `.fc-bg` below.

This change prevents that by specifically targeting the `.fc-bg` class.
