### PR TITLE
Week number support

### DIFF
--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -73,6 +73,8 @@ class SettingsController extends Controller {
 				return $this->getView();
 			case 'skipPopover':
 				return $this->getSkipPopover();
+			case 'showweeknr':
+				return $this->getShowWeekNr();
 			default:
 				return new JSONResponse([], Http::STATUS_BAD_REQUEST);
 		}
@@ -93,6 +95,8 @@ class SettingsController extends Controller {
 				return $this->setView($value);
 			case 'skipPopover':
 				return $this->setSkipPopover($value);
+			case 'showweeknr':
+				return $this->setShowWeekNr($value);
 			default:
 				return new JSONResponse([], Http::STATUS_BAD_REQUEST);
 		}
@@ -217,6 +221,68 @@ class SettingsController extends Controller {
 	 * @return bool
 	 */
 	private function isSkipPopoverValueAllowed($value) {
+		$allowedValues = [
+			'yes',
+			'no'
+		];
+
+		return in_array($value, $allowedValues);
+	}
+
+	/**
+	 * set config value for showing week numbers
+	 *
+	 * @param $value
+	 * @return JSONResponse
+	 */
+	private function setShowWeekNr($value) {
+		if (!$this->isShowWeekNrValueAllowed($value)) {
+			return new JSONResponse([], Http::STATUS_UNPROCESSABLE_ENTITY);
+		}
+
+		try {
+			$this->config->setUserValue(
+				$this->userId,
+				$this->appName,
+				'currentShowWeekNr',
+				$value
+			);
+		} catch(\Exception $e) {
+			return new JSONResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+
+		return new JSONResponse();
+	}
+
+	/**
+	 * get config value for showing week numbers
+	 *
+	 * @return JSONResponse
+	 */
+	private function getShowWeekNr() {
+		try {
+			$value = $this->config->getUserValue(
+				$this->userId,
+				$this->appName,
+				'currentShowWeekNr',
+				'no'
+			);
+		} catch(\Exception $e) {
+			return new JSONResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+
+		return new JSONResponse([
+			'value' => $value,
+		]);
+	}
+
+	/**
+	 * check if value for showWeekNr is allowed
+	 *
+	 * @param $value
+	 * @return bool
+	 */
+	private function isShowWeekNrValueAllowed($value) {
 		$allowedValues = [
 			'yes',
 			'no'

--- a/controller/viewcontroller.php
+++ b/controller/viewcontroller.php
@@ -82,12 +82,14 @@ class ViewController extends Controller {
 		$appVersion = $this->config->getAppValue($this->appName, 'installed_version');
 		$defaultView = $this->config->getUserValue($userId, $this->appName, 'currentView', 'month');
 		$skipPopover = $this->config->getUserValue($userId, $this->appName, 'skipPopover', 'no');
+		$weekNumbers = $this->config->getUserValue($userId, $this->appName, 'currentShowWeekNr', 'no');
 		
 		return new TemplateResponse('calendar', 'main', [
 			'appVersion' => $appVersion,
 			'defaultView' => $defaultView,
 			'emailAddress' => $emailAddress,
 			'skipPopover' => $skipPopover,
+			'weekNumbers' => $weekNumbers,
 			'supportsClass' => $supportsClass
 		]);
 	}

--- a/css/app/calendarlist.css
+++ b/css/app/calendarlist.css
@@ -351,6 +351,7 @@ ul.dropdown-menu li > a:hover {
 .fc .fc-axis,
 .fc-day-grid-event .fc-time,
 .fc-ltr .fc-basic-view .fc-day-number,
+.fc-ltr .fc-basic-view .fc-week-number,
 .fc-time-grid-event .fc-time {
 	opacity: .8;
 	font-size: 80%;

--- a/js/app/controllers/settingscontroller.js
+++ b/js/app/controllers/settingscontroller.js
@@ -26,13 +26,14 @@
  * Description: Takes care of the Calendar Settings.
  */
 
-app.controller('SettingsController', ['$scope', '$uibModal', 'SettingsService',
-	function ($scope, $uibModal, SettingsService) {
+app.controller('SettingsController', ['$scope', '$uibModal', 'SettingsService', 'fc',
+	function ($scope, $uibModal, SettingsService, fc) {
 		'use strict';
 
 		$scope.settingsCalDavLink = OC.linkToRemote('dav') + '/';
 		$scope.settingsCalDavPrincipalLink = OC.linkToRemote('dav') + '/principals/users/' + escapeHTML(encodeURIComponent(oc_current_user)) + '/';
 		$scope.skipPopover = angular.element('#fullcalendar').attr('data-skipPopover');
+		$scope.settingsShowWeekNr = angular.element('#fullcalendar').attr('data-weekNumbers');
 
 		angular.element('#import').on('change', function () {
 			var filesArray = [];
@@ -65,5 +66,15 @@ app.controller('SettingsController', ['$scope', '$uibModal', 'SettingsService',
 			angular.element('#fullcalendar').attr('data-skipPopover', newValue);
 			SettingsService.setSkipPopover(newValue);
 		};
+
+		$scope.updateShowWeekNr = function() {
+			const newValue = $scope.settingsShowWeekNr;
+			angular.element('#fullcalendar').attr('data-weekNumbers', newValue);
+			SettingsService.setShowWeekNr(newValue);
+			if (fc.elm) {
+				fc.elm.fullCalendar('option', 'weekNumbers', (newValue === 'yes'));
+			}
+		};
+
 	}
 ]);

--- a/js/app/directives/fullCalendarDirective.js
+++ b/js/app/directives/fullCalendarDirective.js
@@ -67,7 +67,7 @@ app.constant('fc', {})
 				monthNamesShort: monthNamesShort,
 				nowIndicator: true,
 				selectable: true,
-				weekNumbers: true,
+				weekNumbers: (attrs.weeknumbers === 'yes'),
 				weekNumbersWithinDays: true,
 			};
 			const controllerConfig = scope.$parent.fcConfig;

--- a/js/app/directives/fullCalendarDirective.js
+++ b/js/app/directives/fullCalendarDirective.js
@@ -62,7 +62,7 @@ app.constant('fc', {})
 				firstDay: firstDay,
 				header: false,
 				height: windowElement.height() - headerSize,
-				lang: moment.locale(),
+				locale: moment.locale(),
 				monthNames: monthNames,
 				monthNamesShort: monthNamesShort,
 				nowIndicator: true,

--- a/js/app/directives/fullCalendarDirective.js
+++ b/js/app/directives/fullCalendarDirective.js
@@ -67,6 +67,8 @@ app.constant('fc', {})
 				monthNamesShort: monthNamesShort,
 				nowIndicator: true,
 				selectable: true,
+				weekNumbers: true,
+				weekNumbersWithinDays: true,
 			};
 			const controllerConfig = scope.$parent.fcConfig;
 			const config = angular.extend({}, baseConfig, controllerConfig);

--- a/js/app/service/settingsservice.js
+++ b/js/app/service/settingsservice.js
@@ -69,4 +69,27 @@ app.service('SettingsService', ['$rootScope', '$http', function($rootScope, $htt
 			return true;
 		});
 	};
+
+	this.getShowWeekNr = function() {
+		return $http({
+			method: 'GET',
+			url: $rootScope.baseUrl + 'config',
+			params: {key: 'showweeknr'}
+		}).then(function(response) {
+			return response.data.value;
+		});
+	};
+
+	this.setShowWeekNr = function(value) {
+		return $http({
+			method: 'POST',
+			url: $rootScope.baseUrl + 'config',
+			data: {
+				key: 'showweeknr',
+				value: value
+			}
+		}).then(function() {
+			return true;
+		});
+	};
 }]);

--- a/js/config/config.js
+++ b/js/config/config.js
@@ -31,8 +31,8 @@ app.config(['$provide', '$httpProvider',
 			allowXName: true
 		};
 
-		angular.forEach($.fullCalendar.langs, function(obj, lang) {
-			$.fullCalendar.lang(lang, {
+		angular.forEach($.fullCalendar.locales, function(obj, locale) {
+			$.fullCalendar.locale(locale, {
 				timeFormat: obj.mediumTimeFormat
 			});
 
@@ -43,7 +43,7 @@ app.config(['$provide', '$httpProvider',
 					var overwrite = {};
 					overwrite[propToCheck] = obj[propToCheck].replace('HH', 'H');
 
-					$.fullCalendar.lang(lang, overwrite);
+					$.fullCalendar.locale(locale, overwrite);
 				}
 			});
 		});

--- a/templates/part.fullcalendar.php
+++ b/templates/part.fullcalendar.php
@@ -28,6 +28,7 @@
 	data-defaultView="<?php p($_['defaultView']); ?>"
 	data-emailAddress="<?php p($_['emailAddress']); ?>"
 	data-skipPopover="<?php p($_['skipPopover']); ?>"
+	data-weekNumbers="<?php p($_['weekNumbers']); ?>"
 	fc
 	id="fullcalendar">
 </div>

--- a/templates/part.settings.php
+++ b/templates/part.settings.php
@@ -41,6 +41,12 @@
 					<?php p($l->t('Skip simple event editor')); ?>
 				</label>
 			</li>
+			<li class="settings-fieldset-interior-item settings-fieldset-interior-weeknumbers">
+				<label>
+					<input type="checkbox" ng-change="updateShowWeekNr()" ng-model="settingsShowWeekNr" ng-true-value="'yes'" ng-false-value="'no'"/>
+					<?php p($l->t('Show week numbers')); ?>
+				</label>
+			</li>
 			<li class="settings-fieldset-interior-item settings-fieldset-interior-upload">
 				<input type="file" name="file" accept="text/calendar" multiple id="import" />
 				<span href="#" class="settings-upload svg icon-upload"><?php p($l->t('Import calendar')); ?></span>

--- a/tests/unit/controller/viewcontrollerTest.php
+++ b/tests/unit/controller/viewcontrollerTest.php
@@ -139,6 +139,7 @@ class ViewControllerTest extends \PHPUnit_Framework_TestCase {
 				'defaultView' => 'someView',
 				'emailAddress' => 'test@bla.com',
 				'skipPopover' => 'someSkipPopoverValue',
+				'weekNumbers' => false,
 				'supportsClass' => $expectsSupportsClass
 			], $actual->getParams());
 			$this->assertEquals('main', $actual->getTemplateName());

--- a/tests/unit/controller/viewcontrollerTest.php
+++ b/tests/unit/controller/viewcontrollerTest.php
@@ -131,6 +131,11 @@ class ViewControllerTest extends \PHPUnit_Framework_TestCase {
 				->with('user123', $this->appName, 'skipPopover', 'no')
 				->will($this->returnValue('someSkipPopoverValue'));
 
+			$this->config->expects($this->at(5))
+				->method('getUserValue')
+				->with('user123', $this->appName, 'currentShowWeekNr', 'no')
+				->will($this->returnValue('someShowWeekNrValue'));
+
 			$actual = $this->controller->index();
 
 			$this->assertInstanceOf('OCP\AppFramework\Http\TemplateResponse', $actual);
@@ -139,7 +144,7 @@ class ViewControllerTest extends \PHPUnit_Framework_TestCase {
 				'defaultView' => 'someView',
 				'emailAddress' => 'test@bla.com',
 				'skipPopover' => 'someSkipPopoverValue',
-				'weekNumbers' => false,
+				'weekNumbers' => 'someShowWeekNrValue',
 				'supportsClass' => $expectsSupportsClass
 			], $actual->getParams());
 			$this->assertEquals('main', $actual->getTemplateName());


### PR DESCRIPTION
This PR follows on https://github.com/owncloudarchive/calendar/issues/929 and is work in progress.

This branch provides:
- A recent development master of FullCalendar modified with a proposed new feature to display the week numbers in the day cells instead of in a separate column.
- Changes in ownCloud Calendar to accommodate the new feature, such as CSS styling and a user setting to toggle week number display. 

To do:
- [x] Upstream implementation of week number display in day cells: https://github.com/fullcalendar/fullcalendar/pull/3024.
- [x] How to safely update the view after changing the "Show week numbers" setting, i.e. without losing the current date, view, height, events, etc.? See peternowee/calendar@f5c921d commit message. Currently waiting to see what upstream will do with this: https://github.com/fullcalendar/fullcalendar/issues/564, https://github.com/fullcalendar/fullcalendar/issues/2709.
- [ ] Translation of string "Show week numbers".

I will try to keep this branch up-to-date by regularly merging from owncloud/calendar master and fullcalendar/fullcalendar master.
