### PR TITLE
hide class input for 1.0

### DIFF
--- a/templates/part.eventssidebareditor.php
+++ b/templates/part.eventssidebareditor.php
@@ -49,7 +49,7 @@
 					  autocomplete="off" ></textarea>
   			<textarea ng-model="properties.description.value" type="text" class="advanced--input advanced--textarea"
 					placeholder="<?php p($l->t('Description'));?>" name="description"></textarea>
-			<select id="classSelector" ng-options="class.type as class.displayname for class in classSelect" ng-init="setClassToDefault()" ng-model="properties.class.value"></select>
+			<!--<select id="classSelector" ng-options="class.type as class.displayname for class in classSelect" ng-init="setClassToDefault()" ng-model="properties.class.value"></select>-->
 		</fieldset>
 
 		<ul class="tabHeaders">


### PR DESCRIPTION
Core ignores the class property at the moment. We should hide it, because it's confusing
