### PR TITLE
move alldayevent checkbox above day/time picker

### DIFF
--- a/templates/editor.popover.php
+++ b/templates/editor.popover.php
@@ -16,6 +16,14 @@
 		</fieldset>
 
 		<fieldset class="event-time events--fieldset" ng-disabled="readOnly">
+			<div class="events--checkbox pull-left">
+				<input type="checkbox" name="alldayeventcheckbox"
+					   ng-model="properties.allDay"
+					   id="alldayeventcheckbox" class="event-checkbox"
+					   ng-change="toggledAllDay()" />
+				<label for="alldayeventcheckbox"><?php p($l->t('All day Event'))?></label>
+			</div>
+			<div class="clear-both"></div>	
 			<div class="event-time-interior pull-left">
 				<span><?php p($l->t('starts')); ?></span>
 				<ocdatetimepicker ng-model="properties.dtstart.value" disabletime="properties.allDay"></ocdatetimepicker>
@@ -25,14 +33,6 @@
 				<span><?php p($l->t('ends')); ?></span>
 				<ocdatetimepicker ng-model="properties.dtend.value" disabletime="properties.allDay"></ocdatetimepicker>
 				<span ng-show="showTimezone">{{ properties.dtend.parameters.zone | timezoneFilter }}</span>
-			</div>
-			<div class="clear-both"></div>
-			<div class="events--checkbox pull-left">
-				<input type="checkbox" name="alldayeventcheckbox"
-					   ng-model="properties.allDay"
-					   id="alldayeventcheckbox" class="event-checkbox"
-					   ng-change="toggledAllDay()" />
-				<label for="alldayeventcheckbox"><?php p($l->t('All day Event'))?></label>
 			</div>
 		</fieldset>
 

--- a/templates/editor.sidebar.php
+++ b/templates/editor.sidebar.php
@@ -14,6 +14,14 @@
 		</fieldset>
 
 		<fieldset class="advanced--fieldset" ng-disabled="readOnly">
+			<div class="advanced--checkbox pull-left">
+				<input type="checkbox" name="alldayeventcheckbox"
+					   ng-model="properties.allDay"
+					   id="alldayeventcheckbox" class="event-checkbox"
+					   ng-change="toggledAllDay()"/>
+				<label for="alldayeventcheckbox"><?php p($l->t('All day Event'))?></label>
+			</div>
+			<div class="clear-both"></div>
 			<div class="event-time-interior pull-left pull-half">
 				<span><?php p($l->t('starts')); ?></span>
 				<ocdatetimepicker ng-model="properties.dtstart.value" disabletime="properties.allDay"></ocdatetimepicker>
@@ -25,14 +33,6 @@
 				<ocdatetimepicker ng-model="properties.dtend.value" disabletime="properties.allDay"></ocdatetimepicker>
 				<select ng-options="timezone.value as timezone.displayname | timezoneWithoutContinentFilter group by timezone.group for timezone in timezones" ng-model="properties.dtend.parameters.zone" ng-show="edittimezone || readOnly" ng-disabled="properties.allDay"
 					ng-change="loadTimezone(properties.dtend.parameters.zone)"></select>
-			</div>
-			<div class="clear-both"></div>
-			<div class="advanced--checkbox pull-left">
-				<input type="checkbox" name="alldayeventcheckbox"
-					   ng-model="properties.allDay"
-					   id="alldayeventcheckbox" class="event-checkbox"
-					   ng-change="toggledAllDay()"/>
-				<label for="alldayeventcheckbox"><?php p($l->t('All day Event'))?></label>
 			</div>
 			<div class="pull-right">
 				<button class="button btn-default btn-timezone" ng-click="edittimezone = !edittimezone" ng-show="!readOnly">


### PR DESCRIPTION
Move alldayevent checkbox above start end day and time picker

This way, the ui elements are in a better arrangement when creating / editing events using the TAB key to advance from one field to the next.

Currently the user has to TAB to the alldayevent checkbox, skipping the disabled time picker, then SHIFT-TAB back to add a start and end time.
