### PR TITLE
add tabindex to event editor for better navigation

### DIFF
--- a/js/public/app.js
+++ b/js/public/app.js
@@ -1792,8 +1792,8 @@ app.directive('ocdatetimepicker', ["$compile", "$timeout", function($compile, $t
 			disabletime: '=disabletime'
 		},
 		link: function (scope, element, attrs, ngModelCtrl) {
-			var templateHTML = '<input type="text" ng-model="date" class="events--date" />';
-			templateHTML += '<input type="text" ng-model="time" class="events--time" ng-disabled="disabletime"/>';
+			var templateHTML = '<input type="text" ng-model="date" class="events--date" tabindex="104" />';
+			templateHTML += '<input type="text" ng-model="time" class="events--time" ng-disabled="disabletime" tabindex="104"/>';
 			var template = angular.element(templateHTML);
 
 			scope.date = null;

--- a/templates/editor.popover.php
+++ b/templates/editor.popover.php
@@ -7,12 +7,13 @@
 					ng-model="properties.summary.value"
 					placeholder="<?php p($l->t('Title of the Event'));?>"
 					name="title" type="text"
-					autofocus="autofocus"
+                                        autofocus="autofocus"
+                                        tabindex="101"
 			/>
 			<select
 					ng-model="calendar"
 					ng-init="calendar = oldCalendar || calendars[0]"
-					ng-options="c as c.displayname for c in calendars | orderBy:['order'] | calendarSelectorFilter: oldCalendar"></select>
+					ng-options="c as c.displayname for c in calendars | orderBy:['order'] | calendarSelectorFilter: oldCalendar" tabindex="102"></select>
 		</fieldset>
 
 		<fieldset class="event-time events--fieldset" ng-disabled="readOnly">
@@ -31,7 +32,7 @@
 				<input type="checkbox" name="alldayeventcheckbox"
 					   ng-model="properties.allDay"
 					   id="alldayeventcheckbox" class="event-checkbox"
-					   ng-change="toggledAllDay()" />
+					   ng-change="toggledAllDay()" tabindex="103"/>
 				<label for="alldayeventcheckbox"><?php p($l->t('All day Event'))?></label>
 			</div>
 		</fieldset>
@@ -40,32 +41,34 @@
 			<textarea ng-model="properties.location.value" type="text" class="events--input"
 				   placeholder="<?php p($l->t('Location'));?>" name="location"
 					  uib-typeahead="location.name for location in searchLocation($viewValue)" typeahead-show-hint="true" typeahead-min-length="3"
-					  typeahead-on-select="selectLocationFromTypeahead($item)"></textarea>
+					  typeahead-on-select="selectLocationFromTypeahead($item)" tabindex="105"></textarea>
 		</fieldset>
 
 		<fieldset class="events--fieldset pull-left" ng-show="!readOnly">
-			<button ng-click="delete()" ng-show="!is_new" class="events--button button btn delete">
+			<button ng-click="delete()" ng-show="!is_new" class="events--button button btn delete" tabindex="109">
 				<?php p($l->t('Delete')); ?>
 			</button>
-			<button ng-click="cancel()" class="events--button button btn">
+			<button ng-click="cancel()" class="events--button button btn" tabindex="108">
 				<?php p($l->t('Cancel')); ?>
 			</button>
 		</fieldset>
 
 		<fieldset class="events--fieldset pull-right" ng-show="!readOnly">
-			<button ng-click="close('proceed')" class="events--button button btn">
+			<button ng-click="close('proceed')" class="events--button button btn" tabindex="106">
 				<?php p($l->t('More ...')); ?>
 			</button>
 			<button
 				class="events--button button btn primary"
 				ng-click="close('save')"
-				ng-show="is_new">
+                                ng-show="is_new"
+                                tabindex="107">
 				<?php p($l->t('Create')); ?>
 			</button>
 			<button
 				class="evens--button button btn primary"
 				ng-click="close('save')"
-				ng-show="!is_new">
+				ng-show="!is_new"
+                                tabindex="107">
 				<?php p($l->t('Update')); ?>
 			</button>
 		</fieldset>

--- a/templates/editor.sidebar.php
+++ b/templates/editor.sidebar.php
@@ -6,11 +6,12 @@
 					ng-model="properties.summary.value"
 					placeholder="<?php p($l->t('Title of the Event'));?>"
 					name="title" type="text"
-					autofocus="autofocus"/>
+                                        autofocus="autofocus"
+                                        tabindex="101"/>
 			<select
 					ng-model="calendar"
 					ng-init="calendar = oldCalendar || calendars[0]"
-					ng-options="c as c.displayname for c in calendars | orderBy:['order'] | calendarSelectorFilter: oldCalendar"></select>
+					ng-options="c as c.displayname for c in calendars | orderBy:['order'] | calendarSelectorFilter: oldCalendar" tabindex="102"></select>
 		</fieldset>
 
 		<fieldset class="advanced--fieldset" ng-disabled="readOnly">
@@ -31,7 +32,7 @@
 				<input type="checkbox" name="alldayeventcheckbox"
 					   ng-model="properties.allDay"
 					   id="alldayeventcheckbox" class="event-checkbox"
-					   ng-change="toggledAllDay()"/>
+					   ng-change="toggledAllDay()" tabindex="103"/>
 				<label for="alldayeventcheckbox"><?php p($l->t('All day Event'))?></label>
 			</div>
 			<div class="pull-right">
@@ -46,9 +47,9 @@
 				   placeholder="<?php p($l->t('Location'));?>" name="location"
 					  uib-typeahead="location.name for location in searchLocation($viewValue)" typeahead-show-hint="true" typeahead-min-length="3"
 					  typeahead-on-select="selectLocationFromTypeahead($item)"
-					  autocomplete="off" ></textarea>
+					  autocomplete="off" tabindex="105"></textarea>
   			<textarea ng-model="properties.description.value" type="text" class="advanced--input advanced--textarea"
-					placeholder="<?php p($l->t('Description'));?>" name="description"></textarea>
+					placeholder="<?php p($l->t('Description'));?>" name="description" tabindex="106"></textarea>
 			<!--<select id="classSelector" ng-options="class.type as class.displayname for class in classSelect" ng-init="setClassToDefault()" ng-model="properties.class.value"></select>-->
 		</fieldset>
 
@@ -81,37 +82,43 @@
 			<button
 				class="events--button button btn delete btn-half pull-left"
 				ng-click="delete()"
-				ng-show="!is_new">
+				ng-show="!is_new"
+                                tabindex="110">
 				<?php p($l->t('Delete')); ?>
 			</button>
 			<button
 				class="evens--button button btn btn-half pull-right"
 				ng-click="cancel()"
-				ng-show="!is_new">
+				ng-show="!is_new"
+                                tabindex="108">
 				<?php p($l->t('Cancel')); ?>
 			</button>
 			<button
 				class="evens--button button btn btn-full"
 				ng-click="cancel()"
-				ng-show="is_new">
+				ng-show="is_new"
+                                tabindex="108">
 				<?php p($l->t('Cancel')); ?>
 			</button>
 			<button
 				class="evens--button button btn btn-full"
 				ng-click="export()"
-				ng-show="!is_new">
+				ng-show="!is_new"
+                                tabindex="109">
 				<?php p($l->t('Export')); ?>
 			</button>
 			<button
 				class="events--button button btn primary btn-full"
 				ng-click="save()"
-				ng-show="is_new">
+                                ng-show="is_new"
+                                tabindex="107">
 				<?php p($l->t('Create')); ?>
 			</button>
 			<button
 				class="evens--button button btn primary btn-full"
 				ng-click="save()"
-				ng-show="!is_new">
+				ng-show="!is_new"
+                                tabindex="107">
 				<?php p($l->t('Update')); ?>
 			</button>
 		</fieldset>


### PR DESCRIPTION
alternative to https://github.com/owncloud/calendar/pull/367 as suggested by @georgehrke 

Improves navigation with TAB key in event editor by setting tabindex of the alldayevent checkbox before the tabindex of the date & time fields.
