### PR TITLE
increase events size to be same font size as other elements, not so small

### DIFF
--- a/css/calendarlist.css
+++ b/css/calendarlist.css
@@ -266,3 +266,10 @@ ul.dropdown-menu li > a:hover {
 .fc-unthemed th, .fc-unthemed td, .fc-unthemed thead, .fc-unthemed tbody, .fc-unthemed .fc-divider, .fc-unthemed .fc-row, .fc-unthemed .fc-popover {
 	border-color: #eee;
 }
+
+/* properly size events */
+.fc-event {
+	font-size: 13px;
+	line-height: initial;
+	padding-left: 3px;
+}


### PR DESCRIPTION
Currently the events are super small. But they are the most important element in the calendar. So here’s increasing them to the same size as all the other elements (font-size 13px).

Please review @owncloud/designers @georgehrke
