### PR TITLE
Fix random colour if no toHsl function and import calendar loading

### DIFF
--- a/js/app/controllers/importcontroller.js
+++ b/js/app/controllers/importcontroller.js
@@ -64,6 +64,7 @@ app.controller('ImportController', ['$scope', '$rootScope', '$filter', 'Calendar
 								$scope.$apply();
 								$rootScope.$broadcast('refetchEvents', calendar);
 								$scope.closeIfNecessary();
+								calendar.list.loading = false;
 							}
 						});
 					});
@@ -72,7 +73,7 @@ app.controller('ImportController', ['$scope', '$rootScope', '$filter', 'Calendar
 
 			if (file.calendar === 'new') {
 				var name = file.newCalendarName || file.name;
-				var color = file.newCalendarColor || '#1d2d44';
+				var color = file.newCalendarColor || randColour(); // jshint ignore:line
 
 				var components = [];
 				if (file.split.vevent.length > 0) {

--- a/js/app/directives/colorpickerDirective.js
+++ b/js/app/directives/colorpickerDirective.js
@@ -94,13 +94,27 @@ var rgbToHex = function(r, g, b) {
 	return '#' + parseInt(r, 10).toString(16) + parseInt(g, 10).toString(16) + parseInt(b, 10).toString(16);
 };
 
+var listofcolours = [
+	'#31CC7C',
+	'#317CCC',
+	'#FF7A66',
+	'#F1DB50',
+	'#7C31CC',
+	'#CC317C',
+	'#3A3B3D',
+	'#CACBCD'
+];
 
 /*
  * Generate a random colour with the core generator
  */
 var randColour = function() {
 	'use strict';
-	return rgbToHex(hslToRgb(Math.random().toString().toHsl()));
+	if (typeof String.prototype.toHsl === 'function') {
+		return rgbToHex(hslToRgb(Math.random().toString().toHsl()));
+	} else {
+		return listofcolours[Math.floor(Math.random() * listofcolours.length)];
+	}
 };
 
 /**
@@ -111,16 +125,6 @@ var randColour = function() {
 
 app.directive('colorpicker', function() {
 	'use strict';
-	var listofcolours = [
-		'#31CC7C',
-		'#317CCC',
-		'#FF7A66',
-		'#F1DB50',
-		'#7C31CC',
-		'#CC317C',
-		'#3A3B3D',
-		'#CACBCD'
-	];
 	if (typeof String.prototype.toHsl === 'function') {
 		var hsl = "";
 		var hslcolour = "";

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -1050,6 +1050,7 @@ app.controller('ImportController', ['$scope', '$rootScope', '$filter', 'Calendar
 								$scope.$apply();
 								$rootScope.$broadcast('refetchEvents', calendar);
 								$scope.closeIfNecessary();
+								calendar.list.loading = false;
 							}
 						});
 					});
@@ -1058,7 +1059,7 @@ app.controller('ImportController', ['$scope', '$rootScope', '$filter', 'Calendar
 
 			if (file.calendar === 'new') {
 				var name = file.newCalendarName || file.name;
-				var color = file.newCalendarColor || '#1d2d44';
+				var color = file.newCalendarColor || randColour(); // jshint ignore:line
 
 				var components = [];
 				if (file.split.vevent.length > 0) {
@@ -1646,13 +1647,27 @@ var rgbToHex = function(r, g, b) {
 	return '#' + parseInt(r, 10).toString(16) + parseInt(g, 10).toString(16) + parseInt(b, 10).toString(16);
 };
 
+var listofcolours = [
+	'#31CC7C',
+	'#317CCC',
+	'#FF7A66',
+	'#F1DB50',
+	'#7C31CC',
+	'#CC317C',
+	'#3A3B3D',
+	'#CACBCD'
+];
 
 /*
  * Generate a random colour with the core generator
  */
 var randColour = function() {
 	'use strict';
-	return rgbToHex(hslToRgb(Math.random().toString().toHsl()));
+	if (typeof String.prototype.toHsl === 'function') {
+		return rgbToHex(hslToRgb(Math.random().toString().toHsl()));
+	} else {
+		return listofcolours[Math.floor(Math.random() * listofcolours.length)];
+	}
 };
 
 /**
@@ -1663,16 +1678,6 @@ var randColour = function() {
 
 app.directive('colorpicker', function() {
 	'use strict';
-	var listofcolours = [
-		'#31CC7C',
-		'#317CCC',
-		'#FF7A66',
-		'#F1DB50',
-		'#7C31CC',
-		'#CC317C',
-		'#3A3B3D',
-		'#CACBCD'
-	];
 	if (typeof String.prototype.toHsl === 'function') {
 		var hsl = "";
 		var hslcolour = "";


### PR DESCRIPTION
- Generate random colour on import
- Test if core has the toHsl function
- If no core colour generator, random between our default list of colour
- Remove spinner once importing is finished

@georgehrke @jancborchardt @raghunayyar 
Fix #390 and #531
ref and replace #526 
