### PR TITLE
Remove unnacesary max-height for calendars list

### DIFF
--- a/css/calendarlist.css
+++ b/css/calendarlist.css
@@ -22,9 +22,6 @@
  */
 
 
-#app-navigation .calendar-list {
-	max-height: 400px;
-}
 #app-navigation .app-navigation-input {
 	width: 95%;
 }


### PR DESCRIPTION
Fix for https://github.com/owncloud/calendar/issues/552 and https://github.com/owncloud/calendar/issues/556
