### PR TITLE
Cast firstDay input to number for moment >=2.11

### DIFF
--- a/js/app/controllers/calcontroller.js
+++ b/js/app/controllers/calcontroller.js
@@ -228,7 +228,7 @@ app.controller('CalController', ['$scope', '$rootScope', '$window', 'CalendarSer
 				defaultView: angular.element('#fullcalendar').attr('data-defaultView'),
 				header: false,
 				nowIndicator: true,
-				firstDay: moment().startOf('week').format('d'),
+				firstDay: +moment().startOf('week').format('d'),
 				select: function (start, end, jsEvent, view) {
 					var writableCalendars = $scope.calendars.filter(function(elem) {
 						return elem.writable;

--- a/js/app/directives/datetimepickerDirective.js
+++ b/js/app/directives/datetimepickerDirective.js
@@ -70,7 +70,7 @@ app.directive('ocdatetimepicker', function($compile, $timeout) {
 					dayNames: moment.weekdays(),
 					dayNamesMin: moment.weekdaysMin(),
 					dayNamesShort: moment.weekdaysShort(),
-					firstDay: localeData.firstDayOfWeek(),
+					firstDay: +localeData.firstDayOfWeek(),
 					minDate: null,
 					showOtherMonths: true,
 					selectOtherMonths: true,

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -343,7 +343,7 @@ app.controller('CalController', ['$scope', '$rootScope', '$window', 'CalendarSer
 				defaultView: angular.element('#fullcalendar').attr('data-defaultView'),
 				header: false,
 				nowIndicator: true,
-				firstDay: moment().startOf('week').format('d'),
+				firstDay: +moment().startOf('week').format('d'),
 				select: function (start, end, jsEvent, view) {
 					var writableCalendars = $scope.calendars.filter(function(elem) {
 						return elem.writable;
@@ -1798,7 +1798,7 @@ app.directive('ocdatetimepicker', ["$compile", "$timeout", function($compile, $t
 					dayNames: moment.weekdays(),
 					dayNamesMin: moment.weekdaysMin(),
 					dayNamesShort: moment.weekdaysShort(),
-					firstDay: localeData.firstDayOfWeek(),
+					firstDay: +localeData.firstDayOfWeek(),
 					minDate: null,
 					showOtherMonths: true,
 					selectOtherMonths: true,


### PR DESCRIPTION
Starting with moment.js 2.11.0, the first day of the week (`dow`) needs to be supplied as a number type (e.g. `0` for Sunday). Supplying a string (e.g. `"0"` for Sunday) will result in incorrect week number calculation. This Calendar app sets FullCalendar's `firstDay` option, which in turn sets moment.js' `dow`.

Both moment.js and FullCalendar have indicated that they will not be accepting or sanitizing strings (see moment/moment#2900 and fullcalendar/fullcalendar#3014).

Note that FullCalendar is supplied by this Calendar app, but that moment.js is supplied by core. Both ownCloud core and Nextcloud core currently still depend on moment 2.10.

Also note that week number functionality for this Calendar app is still under development (see owncloud/calendar#262).

However, when using the week number functionality in combination with a manual upgrade of core's moment to version 2.13.0, week numbers were indeed calculated incorrectly. Screenshots:

Week numbers + moment 2.13.0, week numbers incorrect:
![20160626 oc 3d65979 cal c9050e7 pn test-fc-weeknr 63a0b26 fc 4eef482 pn weeknr-in-daycell d9c2dd8 moment 2 13 0 week numbers wrong](https://cloud.githubusercontent.com/assets/10220583/16362521/2254de4e-3bb1-11e6-94c1-d4a394524c81.png)

Week numbers + moment 2.13.0 + this fix, week numbers correct again:
![20160626 oc 3d65979 cal c9050e7 pn test-fc-weeknr 63a0b26 fc 4eef482 pn weeknr-in-daycell d9c2dd8 moment 2 13 0 week numbers fixed](https://cloud.githubusercontent.com/assets/10220583/16362522/23d061b2-3bb1-11e6-8491-19d7d1c0dc07.png)

This commit contains a preventive fix that adds unary plusses to the input for FullCalendar's `firstDay` option, so that any string is cast to number. It can be applied now already and will prevent problems when core upgrades its moment.js dependency to a higher version.
