### PR TITLE
Fix vertical calendar alignment, get rid of inline css

### DIFF
--- a/css/calendarlist.css
+++ b/css/calendarlist.css
@@ -184,13 +184,29 @@
 	display: inline-block;
 }
 
+#app-navigation .app-navigation-list-item .utils span.action.withitems {
+	display: inline-block;
+	vertical-align: top;
+}
+
 #app-navigation .app-navigation-list-item .utils .action span {
 	display: inline-block;
-	line-height: 44px;
-	height: 16px;
+	line-height: 20px;
+	height: 20px;
 	width: 16px;
 	padding: 12px 6px;
 	cursor: pointer;
+	vertical-align: top;
+}
+#app-navigation .app-navigation-list-item .utils .action .icon-shared {
+	padding: 12px 0;
+}
+
+#app-navigation .app-navigation-list-item span.calendarlist-icon.shared {
+	width: 40px;
+	opacity: 1;
+	padding-left: 0;
+	padding-right: 5px;
 }
 
 #app-navigation .app-navigation-list-item:hover .calendar-share-list .utils .action span {

--- a/templates/part.calendarlist.item.php
+++ b/templates/part.calendarlist.item.php
@@ -56,8 +56,8 @@
 		</span>
 		<!-- Add a label if the calendar has shares -->
 		<span
+			class="calendarlist-icon shared"
 			ng-if="item.calendar.isShared() && item.calendar.isShareable()"
-			style="position: relative; bottom: 16px; left: -12px; width: 30px; opacity: 1"
 			ng-click="item.toggleEditingShares()">
 				<?php p($l->t('Shared'))?>
 		</span>


### PR DESCRIPTION
As an addition to #636 I fixed the vertical alignment of the shared label and got rid of the inline css and the relative positioning. This also is the "somewhat more elegant solution" requested in https://github.com/owncloud/calendar/pull/571#discussion_r66419140 I think :wink: 

Also see the screenshots.

Before:
![before](https://cloud.githubusercontent.com/assets/2496460/17266226/e5880ee6-55f5-11e6-8108-10d6523e8899.png)

After:
![after](https://cloud.githubusercontent.com/assets/2496460/17266225/e3a54c2e-55f5-11e6-9075-e79ce4a53371.png)
