### PR TITLE
Fix on hover flickering share delete icon

### DIFF
--- a/css/app/calendarlist.css
+++ b/css/app/calendarlist.css
@@ -238,8 +238,8 @@
 	padding-right: 5px;
 }
 
-#app-navigation .app-navigation-list-item:hover .calendar-share-list .utils .action span {
-	padding: 0;
+#app-navigation .app-navigation-list-item .calendar-share-list .utils .action span {
+	padding: 0 6px;
 }
 
 #app-navigation .app-navigation-list-item:hover .utils.active {


### PR DESCRIPTION
This PR fixes the wrongly positioned share delete icon which jumped to the correct position on hover.

Before:
![before](https://cloud.githubusercontent.com/assets/2496460/17346116/94f2d24c-5909-11e6-8d44-c997b448366f.png)

After (or before while hovering):
![after](https://cloud.githubusercontent.com/assets/2496460/17346351/7c7fc868-590a-11e6-8f6d-c5f23b3b3b87.png)
