### PR TITLE
fix display of details event sidebar on low resolutions

### DIFF
--- a/css/app/eventdialog.css
+++ b/css/app/eventdialog.css
@@ -117,13 +117,8 @@
 }
 
 .advanced--container {
-	position: absolute;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
 	padding: 20px;
-	margin-bottom: 120px;
+	margin-bottom: 40px;
 }
 
 .advanced--fieldset {
@@ -185,10 +180,7 @@ button.delete:focus {
 .advanced .advanced--button-area {
 	border-top: 1px solid #eee;
 	padding: 5px 20px;
-	position: absolute;
-	left: 0;
-	right: 0;
-	bottom: 0;
+	width: calc(100% - 40px);
 }
 
 .advanced .pull-half {


### PR DESCRIPTION
Buttons were shown in the middle of the view on low resolutions
![event-details-lowres](https://cloud.githubusercontent.com/assets/2197836/17371453/35ad0626-59a0-11e6-9ddd-3908494a93f2.png)

However, on high res, there are no longer displayed totally on the bottom, so please tell me if that's an issue.
![event-details-highres](https://cloud.githubusercontent.com/assets/2197836/17371552/928dd58c-59a0-11e6-99fc-263aab39dd9c.png)
