### PR TITLE
Predefine the "None" timezone

### DIFF
--- a/js/app/service/timezoneservice.js
+++ b/js/app/service/timezoneservice.js
@@ -31,6 +31,7 @@ app.service('TimezoneService', ['$rootScope', '$http', 'Timezone', 'TimezoneList
 		this._timezones.UTC = new Timezone(ICAL.TimezoneService.get('UTC'));
 		this._timezones.GMT = this._timezones.UTC;
 		this._timezones.Z = this._timezones.UTC;
+		this._timezones.FLOATING = new Timezone(ICAL.Timezone.localTimezone);
 
 		this.listAll = function () {
 			return TimezoneListProvider;


### PR DESCRIPTION
Fixes issue #664 
Rather than removing "None", TimezoneService defines "FLOATING" as ICAL.Timezone.localTimezone similarly to how it defines the UTC time zones. This prevents the attempt to download the FLOATING .ics file which does not exist.
