### PR TITLE
Rename lang to locale for FullCalendar 3.0.0

### DIFF
--- a/js/app/directives/fullCalendarDirective.js
+++ b/js/app/directives/fullCalendarDirective.js
@@ -62,7 +62,7 @@ app.constant('fc', {})
 				firstDay: firstDay,
 				header: false,
 				height: windowElement.height() - headerSize,
-				lang: moment.locale(),
+				locale: moment.locale(),
 				monthNames: monthNames,
 				monthNamesShort: monthNamesShort,
 				nowIndicator: true,

--- a/js/config/config.js
+++ b/js/config/config.js
@@ -31,8 +31,8 @@ app.config(['$provide', '$httpProvider',
 			allowXName: true
 		};
 
-		angular.forEach($.fullCalendar.langs, function(obj, lang) {
-			$.fullCalendar.lang(lang, {
+		angular.forEach($.fullCalendar.locales, function(obj, locale) {
+			$.fullCalendar.locale(locale, {
 				timeFormat: obj.mediumTimeFormat
 			});
 
@@ -43,7 +43,7 @@ app.config(['$provide', '$httpProvider',
 					var overwrite = {};
 					overwrite[propToCheck] = obj[propToCheck].replace('HH', 'H');
 
-					$.fullCalendar.lang(lang, overwrite);
+					$.fullCalendar.locale(locale, overwrite);
 				}
 			});
 		});


### PR DESCRIPTION
In FullCalendar 3.0.0, the `lang` option was renamed to `locale`.

Using the old `lang` option, the FullCalendar locale will not be set, which might lead to unexpected results. For example, week numbers will be calculated wrong (using the week number option proposed in owncloud/calendar#262):

**Before this fix**
Calendar app with FullCalendar 3.0.0, German locale, using option `lang`, showing week numbers 1 too high:
![20160908 oc week number wrong after fc v3 renamed lang to locale](https://cloud.githubusercontent.com/assets/10220583/18345991/544bf30a-75be-11e6-9ec6-fa09f3868e95.png)

**After this fix**
Calendar app with FullCalendar 3.0.0, German locale, using option `locale`, showing correct week numbers:
![20160908 oc week number fixed after fc v3 renamed lang to locale](https://cloud.githubusercontent.com/assets/10220583/18345995/55db7e0c-75be-11e6-87d8-d66fdb517f82.png)

Filing a separate PR because it might lead to other problems (not related to week numbers) as well.
