### PR TITLE
fix linebreak issue for fullcalendar events

### DIFF
--- a/css/app/calendar.css
+++ b/css/app/calendar.css
@@ -26,6 +26,10 @@
 	width: 100%;
 }
 
+#fullcalendar table {
+	white-space: inherit !important;
+}
+
 .fc-state-highlight.fc-day-number,
 #fullcalendar tbody tr,
 #fullcalendar tbody tr:hover,


### PR DESCRIPTION
fixes #723

before:
<img width="325" alt="before" src="https://cloud.githubusercontent.com/assets/1250540/18473545/dd00ddb6-79bd-11e6-9de5-0f12fe03227b.png">

after:
<img width="385" alt="after" src="https://cloud.githubusercontent.com/assets/1250540/18473552/e1fb1fb6-79bd-11e6-9a96-bee7fb7e2a6f.png">

please review @raghunayyar @jancborchardt @scroom 
