### PR TITLE
IT l10n: fix translation

### DIFF
--- a/l10n/it.js
+++ b/l10n/it.js
@@ -72,7 +72,7 @@ OC.L10N.register(
     "{type} {time} after the event ends" : "{type} {time} dopo la fine dell'evento",
     "{type} at the event's start" : "{type} all'inizio dell'evento",
     "{type} at the event's end" : "{type} alla fine dell'evento",
-    "{type} at {time}" : "{type} alle {time}",
+    "{type} at {time}" : "{type} il {time}",
     "{calendar} shared by {owner}" : "{calendar} condiviso da {owner}",
     "Please enter a valid WebCal-URL" : "Digita un URL WebCal valido",
     "The remote server did not give us access to the calendar (HTTP {code} error)" : "Il server remoto ha negato l'accesso al calendario (errore HTTP {code})",

--- a/l10n/it.json
+++ b/l10n/it.json
@@ -70,7 +70,7 @@
     "{type} {time} after the event ends" : "{type} {time} dopo la fine dell'evento",
     "{type} at the event's start" : "{type} all'inizio dell'evento",
     "{type} at the event's end" : "{type} alla fine dell'evento",
-    "{type} at {time}" : "{type} alle {time}",
+    "{type} at {time}" : "{type} il {time}",
     "{calendar} shared by {owner}" : "{calendar} condiviso da {owner}",
     "Please enter a valid WebCal-URL" : "Digita un URL WebCal valido",
     "The remote server did not give us access to the calendar (HTTP {code} error)" : "Il server remoto ha negato l'accesso al calendario (errore HTTP {code})",


### PR DESCRIPTION
Expansion of `time` variable begins with the weekday. Old translation was therefore grammatically incorrect.