### PR TITLE
Release 1.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
   include:
     - php: 5.6
       env: "DB=sqlite"
-    - php: 7
+    - php: 7.0
       env: "DB=sqlite"
     - php: 7.2
       env: "DB=sqlite"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 1.6.0 - 2018-09-20
+### Fixed
+- Updating fullcalendar to fix translation issues
+  [#907](https://github.com/owncloud/calendar/pull/907)
+- Remove avatars from public calendars due to core change
+  [#909](https://github.com/owncloud/calendar/pull/909)
+- Add support for event series to specify a end
+  [#914](https://github.com/owncloud/calendar/pull/914)
+- Add support for recurrence rule BYDAY
+  [#918](https://github.com/owncloud/calendar/pull/918)
+- Add support to delete individual events of an event series
+  [#920](https://github.com/owncloud/calendar/pull/920)
+- Human friendly repeat options
+  [#922](https://github.com/owncloud/calendar/pull/922)
+- Various library updates
+  [#937](https://github.com/owncloud/calendar/pull/937)
+  [#938](https://github.com/owncloud/calendar/pull/938)
+  [#939](https://github.com/owncloud/calendar/pull/939)
+  [#941](https://github.com/owncloud/calendar/pull/941)
+- Fixing today marker
+  [#942](https://github.com/owncloud/calendar/pull/942)
+- Fixing event update handling to allow proper integration via e-mail. Tested with Thunderbird and GMail
+  [#944](https://github.com/owncloud/calendar/pull/944)
+- Recomputing EXDATE in case DTSTART changes
+  [#946](https://github.com/owncloud/calendar/pull/946)
+
 ## 1.5.7 - 2018-03-06
 ### Fixed
 - Fix user and group name escaping in sharing drop down

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,13 +5,13 @@
 	<summary>A Calendar app for ownCloud</summary>
 	<description>The Calendar app is a user interface for ownCloud's CalDAV server. Easily sync events from various devices with your ownCloud and edit them online.
 
-* 🚀 **Integration with other ownCloud apps!** Currently Contacts - more to come.
-* 🌐 **WebCal Support!** Want to see your favorite team’s matchdays in your calendar? No problem!
-* 🙋 **Attendees!** Invite people to your events.
+* 🚀**Integration with other ownCloud apps!** Currently Contacts - more to come.
+* **WebCal Support!** Want to see your favorite team’s matchdays in your calendar? No problem!
+* **Attendees!** Invite people to your events.
 </description>
-	<version>1.5.7</version>
+	<version>1.6.0</version>
 	<licence>AGPL</licence>
-	<author>Georg Ehrke, Raghu Nayyar, Bernhard Fröhler</author>
+	<author>Georg Ehrke, Raghu Nayyar, Bernhard Fröhler, Julian Müller</author>
 	<dependencies>
 		<owncloud min-version="9.1" max-version="10.1" />
 	</dependencies>

--- a/js/app/controllers/calcontroller.js
+++ b/js/app/controllers/calcontroller.js
@@ -275,15 +275,19 @@ app.controller('CalController', ['$scope', 'Calendar', 'CalendarService', 'VEven
 							createAndRenderEvent(result.calendar, result.vevent, view.start, view.end, $scope.defaulttimezone);
 						}
 					}).catch(function(reason) {
+						if (reason === 'cancel') {
+							return;
+						}
 						if (reason === 'delete') {
 							deleteAndRemoveEvent(vevent, fcEvent);
+							return;
 						}
-						else if(reason === 'deleteOccurrence') {
+						if(reason === 'deleteOccurrence') {
 							deleteOccurrence(vevent, fcEvent);
+							return;
 						}
-						else {
-							throw reason;
-						}
+						// unhandled -> throw
+						throw reason;
 					});
 				},
 				eventResize: function (fcEvent, delta, revertFunc) {


### PR DESCRIPTION
## 1.6.0 - 2018-09-20
### Fixed
- Updating fullcalendar to fix translation issues
  [#907](https://github.com/owncloud/calendar/pull/907)
- Remove avatars from public calendars due to core change
  [#909](https://github.com/owncloud/calendar/pull/909)
- Add support for event series to specify a end
  [#914](https://github.com/owncloud/calendar/pull/914)
- Add support for recurrence rule BYDAY
  [#918](https://github.com/owncloud/calendar/pull/918)
- Add support to delete individual events of an event series
  [#920](https://github.com/owncloud/calendar/pull/920)
- Human friendly repeat options
  [#922](https://github.com/owncloud/calendar/pull/922)
- Various library updates
  [#937](https://github.com/owncloud/calendar/pull/937)
  [#938](https://github.com/owncloud/calendar/pull/938)
  [#939](https://github.com/owncloud/calendar/pull/939)
  [#941](https://github.com/owncloud/calendar/pull/941)
- Fixing today marker
  [#942](https://github.com/owncloud/calendar/pull/942)
- Fixing event update handling to allow proper integration via e-mail. Tested with Thunderbird and GMail
  [#944](https://github.com/owncloud/calendar/pull/944)
- Recomputing EXDATE in case DTSTART changes
  [#946](https://github.com/owncloud/calendar/pull/946)
