### PR TITLE
Fix missing cancel icons

### DIFF
--- a/css/app/angularBootstrap.css
+++ b/css/app/angularBootstrap.css
@@ -1,6 +1,6 @@
 /*
  * credits to http://getbootstrap.com/
- * Here are all angular-bootstrap necessary elements stored
+ * Here are all necessary angular-bootstrap elements stored
  */
 
 .btn-group {
@@ -138,7 +138,6 @@
 	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
-	background-image: none;
 	border: 1px solid transparent;
 	border-radius: 4px;
 }

--- a/css/app/calendarlist.css
+++ b/css/app/calendarlist.css
@@ -95,6 +95,10 @@
 	width: 80px;
 }
 
+#app-navigation .active {
+	background-color: transparent;
+}
+
 #app-navigation .app-navigation-list {
 	width: 100%;
 }


### PR DESCRIPTION
# What changed
- Gray close/cancel button icons appear now
- Core css overwritten https://github.com/owncloud/core/pull/29963 since the new style doesn't fit here

# How to test

- Build css bundle
- Click on a calendar item to edit/link
- Check if cancel icon appears on cancel/close buttons
- Also check that all active calendars in the left bar have no gray background color