### PR TITLE
Release 1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [1.6.3] - 2019-08-16
+- Fix cancel button
+  [#1007](https://github.com/owncloud/calendar/issues/1007)
+- Fix EXDATE timezone recalculations
+  [#964](https://github.com/owncloud/calendar/pull/964)
+
 ## [1.6.2] - 2019-02-22
 
 - Translate timepicker elements 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
 * **WebCal Support!** Want to see your favorite team’s matchdays in your calendar? No problem!
 * **Attendees!** Invite people to your events.
 </description>
-	<version>1.6.2</version>
+	<version>1.6.3-rc1</version>
 	<licence>AGPL</licence>
 	<author>Georg Ehrke, Raghu Nayyar, Bernhard Fröhler, Julian Müller</author>
 	<dependencies>


### PR DESCRIPTION
## [1.6.3] - 2019-08-16
- Fix cancel button
  [#1007](https://github.com/owncloud/calendar/issues/1007)
- Fix EXDATE timezone recalculations
  [#964](https://github.com/owncloud/calendar/pull/964)
