### PR TITLE
Add vendor-bin to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,8 @@ build/.sass-cache/
 ### Composer ###
 composer.phar
 vendor/
+vendor-bin/**/vendor
+vendor-bin/**/composer.lock
 
 # vim ex mode
 .vimrc


### PR DESCRIPTION
so that we do not accidentally commit unneeded files in `vendor-bin`

(this makes it similar to other apps)