### PR TITLE
Adjusted wrong .jsinthrc path in the gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -208,7 +208,7 @@ gulp.task('_minifyIEJavaScriptVendor', () => {
 
 gulp.task('jslint', () => {
 	return gulp.src(lintJsSources)
-		.pipe(jshint('.jshintrc'))
+		.pipe(jshint('js/.jshintrc'))
 		.pipe(jshint.reporter('default'))
 		.pipe(jshint.reporter('fail'));
 });


### PR DESCRIPTION
Adjusted the jshintrc pathstring in the gulpfile as some gulp commands failed when using the linter