### PR TITLE
Recover makefile appstore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,74 @@
-SHELL := /bin/bash
+# This file is licensed under the Affero General Public License version 3 or
+# later. See the COPYING file.
+# @author Bernhard Posselt <dev@bernhard-posselt.com>
+# @copyright Bernhard Posselt 2016
+# @author Georg Ehrke <oc.list@georgehrke.com>
+# @copyright Georg Ehrke 2016
 
-
-COMPOSER_BIN := $(shell command -v composer 2> /dev/null)
-ifndef COMPOSER_BIN
-    $(error composer is not available on your system, please install composer)
-endif
-
-YARN := $(shell command -v yarn 2> /dev/null)
-NODE_PREFIX=$(shell pwd)
-
-KARMA=$(NODE_PREFIX)/node_modules/.bin/karma
-JSDOC=$(NODE_PREFIX)/node_modules/.bin/jsdoc
+# Generic Makefile for building and packaging a ownCloud app which uses npm and
+# Composer.
+#
+# Dependencies:
+# * make
+# * which
+# * curl: used if phpunit and composer are not installed to fetch them from the web
+# * tar: for building the archive
+# * npm: for building and testing everything JS
+#
+# If no composer.json is in the app root directory, the Composer step
+# will be skipped. The same goes for the package.json which can be located in
+# the app root or the js/ directory.
+#
+# The npm command by launches the npm build script:
+#
+#    npm run build
+#
+# The npm test command launches the npm test script:
+#
+#    npm run test
+#
+# The idea behind this is to be completely testing and build tool agnostic. All
+# build tools and additional package managers should be installed locally in
+# your project, since this won't pollute people's global namespace.
+#
+# The following npm scripts in your package.json install and update the npm
+# dependencies and use gulp as build system (notice how everything is
+# run from the node_modules folder):
+#
+#    "scripts": {
+#        "test": "node node_modules/gulp-cli/bin/gulp.js karma",
+#        "prebuild": "npm install",
+#        "build": "node node_modules/gulp-cli/bin/gulp.js"
+#    },
 
 app_name=$(notdir $(CURDIR))
-doc_files=README.md CHANGELOG.md
-src_dirs=appinfo js l10n templates
-all_src=$(src_dirs) $(doc_files)
-build_dir=$(CURDIR)/build
-dist_dir=$(build_dir)/dist
-tests_acceptance_directory=$(CURDIR)/../../tests/acceptance
+build_tools_directory=$(CURDIR)/build/tools
+source_build_directory=$(CURDIR)/build/source/calendar
+source_artifact_directory=$(CURDIR)/build/artifacts/source
+source_package_name=$(source_artifact_directory)/$(app_name)
+appstore_build_directory=$(CURDIR)/build/appstore/calendar
+appstore_artifact_directory=$(CURDIR)/build/artifacts/appstore
+appstore_package_name=$(appstore_artifact_directory)/$(app_name)
+yarn=$(shell which yarn 2> /dev/null)
+gcp=$(shell which gcp 2> /dev/null)
 
-nodejs_deps=node_modules
+ifeq (, $(gcp))
+	copy_command=cp
+else
+	copy_command=gcp
+endif
 
-# composer
-composer_deps=
-composer_dev_deps=
-acceptance_test_deps=vendor-bin/behat/vendor
-
+# code signing
+# assumes the following:
+# * the app is inside the owncloud/apps folder
+# * the private key is located in ~/.owncloud/calendar.key
+# * the certificate is located in ~/.owncloud/calendar.crt
 occ=$(CURDIR)/../../occ
+phpunit_oc10=$(CURDIR)/../../lib/composer/bin/phpunit
+configdir=$(CURDIR)/../../config
 private_key=$(HOME)/.owncloud/certificates/$(app_name).key
 certificate=$(HOME)/.owncloud/certificates/$(app_name).crt
-sign=$(occ) integrity:sign-app --privateKey="$(private_key)" --certificate="$(certificate)"
+sign=php -f $(occ) integrity:sign-app --privateKey="$(private_key)" --certificate="$(certificate)"
 sign_skip_msg="Skipping signing, either no key and certificate found in $(private_key) and $(certificate) or occ can not be found at $(occ)"
 ifneq (,$(wildcard $(private_key)))
 ifneq (,$(wildcard $(certificate)))
@@ -54,143 +92,80 @@ build:
 yarn:
 	cd js && $(yarn) run build
 
-# Remove the appstore build and generated guests bundle
+# Removes the appstore build
 .PHONY: clean
-clean: clean-nodejs-deps clean-composer-deps
+clean:
 	rm -rf ./build
+	rm -rf css/public
+	rm -rf js/public
 
-.PHONY: clean-nodejs-deps
-clean-nodejs-deps:
-	rm -Rf $(nodejs_deps)
-
-.PHONY: clean-composer-deps
-clean-composer-deps:
-	rm -rf ./vendor
-	rm -Rf vendor-bin/**/vendor vendor-bin/**/composer.lock
-
-# Same as clean but also removes dependencies installed by npm
+# Same as clean but also removes dependencies installed by composer and npm
 .PHONY: distclean
 distclean: clean
+	rm -rf vendor
+	rm -rf node_modules
+	rm -rf js/node_modules
 
-
-# bin file definitions
-PHPUNIT=php -d zend.enable_gc=0  "$(PWD)/../../lib/composer/bin/phpunit"
-PHPUNITDBG=phpdbg -qrr -d memory_limit=4096M -d zend.enable_gc=0 "$(PWD)/../../lib/composer/bin/phpunit"
-PHP_CS_FIXER=php -d zend.enable_gc=0 vendor-bin/owncloud-codestyle/vendor/bin/php-cs-fixer
-PHAN=php -d zend.enable_gc=0 vendor-bin/phan/vendor/bin/phan
-PHPSTAN=php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan
-BEHAT_BIN=vendor-bin/behat/vendor/bin/behat
-
-.DEFAULT_GOAL := help
-
-# start with displaying help
-help: ## Show this help message
-	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//' | sed -e 's/  */ /' | column -t -s :
-
+# Builds the source and appstore package
 .PHONY: dist
-dist: ## Build the source and appstore package
+dist:
+	make source
 	make appstore
 
-# Build the source package for the app store, ignores php and js tests
-.PHONY: appstore
-appstore: ## Build the source package for the app store
-	rm -rf $(dist_dir)
-	mkdir -p $(dist_dir)/$(app_name)
-	cp -R $(all_src) $(dist_dir)/$(app_name)
-
+# Builds the source package
+.PHONY: source
+source:
+	rm -rf $(source_build_directory) $(source_artifact_directory)
+	mkdir -p $(source_build_directory) $(source_artifact_directory)
+	rsync -rv . $(source_build_directory) \
+	--exclude=/.git/ \
+	--exclude=/.idea/ \
+	--exclude=/build/ \
+	--exclude=/js/node_modules/ \
+	--exclude=*.log
 ifdef CAN_SIGN
-	$(sign) --path="$(dist_dir)/$(app_name)"
+	$(sign) --path "$(source_build_directory)"
 else
 	@echo $(sign_skip_msg)
 endif
-	tar -czf $(dist_dir)/$(app_name).tar.gz -C $(dist_dir) $(app_name)
-	tar -cjf $(dist_dir)/$(app_name).tar.bz2 -C $(dist_dir) $(app_name)
+	tar -cvzf $(source_package_name).tar.gz -C $(source_build_directory)/../ $(app_name)
 
-$(nodejs_deps): package.json yarn.lock
-	yarn install && touch $@
+# Builds the source package for the app store, ignores php and js tests
+.PHONY: appstore
+appstore: build
+	rm -rf $(appstore_build_directory) $(appstore_artifact_directory)
+	mkdir -p $(appstore_build_directory) $(appstore_artifact_directory)
+	$(copy_command) --parents -r \
+	"appinfo" \
+	"controller" \
+	"http" \
+	"img" \
+	"l10n" \
+	"templates" \
+	"css/public" \
+	"js/public" \
+	"COPYING" \
+	"CHANGELOG.md" \
+	$(appstore_build_directory)
+ifdef CAN_SIGN
+	mv $(configdir)/config.php $(configdir)/config-2.php
+	$(sign) --path="$(appstore_build_directory)"
+	mv $(configdir)/config-2.php $(configdir)/config.php
+else
+	@echo $(sign_skip_msg)
+endif
+	tar -czf $(appstore_package_name).tar.gz -C $(appstore_build_directory)/../ $(app_name)
 
-$(KARMA): $(nodejs_deps)
-
-##------------
-## Tests
-##------------
-
-# Command for running all tests.
-.PHONY: test
-test: test-php-unit test-js
 
 # Command for running JS and PHP tests. Works for package.json files in the js/
 # and root directory. If phpunit is not installed systemwide, a copy is fetched
 # from the internet
-# .PHONY: test
-# test:
-# 	cd js && $(yarn) run test
-# ifneq ("$(wildcard $(phpunit_oc10))","")
-# 	php $(phpunit_oc10) -c phpunit.xml --coverage-clover coverage.clover
-# else
-# 	phpunit -c phpunit.xml --coverage-clover coverage.clover
-#   phpunit -c phpunit.integration.xml --coverage-clover build/php-unit.clover
-# endif
-
-.PHONY: test-php-codecheck
-test-php-codecheck:
-	# currently fails - as we use a private api
-	# $(occ) app:check-code $(app_name) -c private
-	$(occ) app:check-code $(app_name) -c strong-comparison
-	$(occ) app:check-code $(app_name) -c deprecation
-
-.PHONY: test-php-style
-test-php-style: ## Run php-cs-fixer and check owncloud code-style
-test-php-style: vendor-bin/owncloud-codestyle/vendor
-	$(PHP_CS_FIXER) fix -v --diff --diff-format udiff --dry-run --allow-risky yes
-
-.PHONY: test-php-style-fix
-test-php-style-fix: ## Run php-cs-fixer and fix code style issues
-test-php-style-fix: vendor-bin/owncloud-codestyle/vendor
-	$(PHP_CS_FIXER) fix -v --diff --diff-format udiff --allow-risky yes
-
-.PHONY: test-php-unit
-test-php-unit: ## Run php unit tests
-test-php-unit:
-	$(PHPUNIT) --configuration phpunit.xml --testsuite unit --coverage-clover coverage.clover
-
-.PHONY: test-php-unit-dbg
-test-php-unit-dbg: ## Run php unit tests using phpdbg
-test-php-unit-dbg:
-	$(PHPUNITDBG) --configuration phpunit.xml --testsuite unit
-
-.PHONY: test-js
-test-js: ## Test js files
-test-js: $(nodejs_deps)
-	$(YARN) run test
-
-#
-# Dependency management
-#--------------------------------------
-
-composer.lock: composer.json
-	@echo composer.lock is not up to date.
-
-vendor: composer.lock
-	composer install --no-dev
-
-vendor/bamarni/composer-bin-plugin: composer.lock
-	composer install
-
-vendor-bin/owncloud-codestyle/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/owncloud-codestyle/composer.lock
-	composer bin owncloud-codestyle install --no-progress
-
-vendor-bin/owncloud-codestyle/composer.lock: vendor-bin/owncloud-codestyle/composer.json
-	@echo owncloud-codestyle composer.lock is not up to date.
-
-vendor-bin/phan/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/phan/composer.lock
-	composer bin phan install --no-progress
-
-vendor-bin/phan/composer.lock: vendor-bin/phan/composer.json
-	@echo phan composer.lock is not up to date.
-
-vendor-bin/phpstan/vendor: vendor/bamarni/composer-bin-plugin vendor-bin/phpstan/composer.lock
-	composer bin phpstan install --no-progress
-
-vendor-bin/phpstan/composer.lock: vendor-bin/phpstan/composer.json
-	@echo phpstan composer.lock is not up to date.
+.PHONY: test
+test:
+	cd js && $(yarn) run test
+ifneq ("$(wildcard $(phpunit_oc10))","")
+	php $(phpunit_oc10) -c phpunit.xml --coverage-clover coverage.clover
+else
+	phpunit -c phpunit.xml --coverage-clover coverage.clover
+	# phpunit -c phpunit.integration.xml --coverage-clover build/php-unit.clover
+endif


### PR DESCRIPTION
Fixes issue #1079 

- Revert the `Makefile` changes that were made in PR #1055 - that gets us back to the original `dist` `source` `appstore` etc targets.
- Add/adjust test targets in the format similar to how it is done in other apps, so that code-style, PHP unit tests and JS tests can run "standard" in drone. (without touching any of the existing targets related to dist/source/appstore...)