### PR TITLE
clean vendor-bin from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ clean:
 .PHONY: distclean
 distclean: clean
 	rm -rf vendor
+	rm -Rf vendor-bin/**/vendor vendor-bin/**/composer.lock
 	rm -rf node_modules
 	rm -rf js/node_modules
 


### PR DESCRIPTION
This "standard" clean of the `vendor-bin` dir was missing.
It is needed so that developers can reliably `make distclean` before running tests, and be sure to then get the latest test tools installed.

Note: in this app `make clean` does not clean composer and npm dependencies. That is some piece of history which I am not trying to investigate or refactor.