### PR TITLE
fix: Replace deprecated String.prototype.substr()

### DIFF
--- a/js/app/controllers/calendarlistcontroller.js
+++ b/js/app/controllers/calendarlistcontroller.js
@@ -91,7 +91,7 @@ app.controller('CalendarListController', ['$scope', '$rootScope', '$window', 'Ha
 				let name = splittedICal.name || url;
 
 				if (name.length > 100) {
-					name = name.substr(0, 100);
+					name = name.slice(0, 100);
 				}
 
 				CalendarService.createWebCal(name, color, url)

--- a/js/app/controllers/recurrencecontroller.js
+++ b/js/app/controllers/recurrencecontroller.js
@@ -128,8 +128,8 @@ app.controller('RecurrenceController', function($scope) {
 		if(angular.isDefined($scope.properties.rrule.byday)) {
 			if($scope.custom.freq === 'MONTHLY') {
 				$scope.selected_month_recurrence = 'WEEK';
-				$scope.custom.interval = parseInt($scope.properties.rrule.byday[0].substr(0, $scope.properties.rrule.byday[0].length - 2));
-				$scope.custom.weekday = $scope.properties.rrule.byday[0].substr($scope.properties.rrule.byday[0].length - 2, $scope.properties.rrule.byday[0].length - 1);
+				$scope.custom.interval = parseInt($scope.properties.rrule.byday[0].slice(0, -2));
+				$scope.custom.weekday = $scope.properties.rrule.byday[0].slice(-2);
 			}
 			else {
 				angular.forEach($scope.properties.rrule.byday, function(value) {

--- a/js/app/factory/calendarFactory.js
+++ b/js/app/factory/calendarFactory.js
@@ -59,7 +59,7 @@ app.service('CalendarFactory', function($window, DavClient, Calendar, WebCal, co
 			// but some browsers can't parse that *cough cough* Safari 9 *cough cough*
 			// Safari 10 seems to support this though
 			if (colorProp.length === 9) {
-				return colorProp.substr(0,7);
+				return colorProp.slice(0,7);
 			}
 			return colorProp;
 		} else {
@@ -114,7 +114,7 @@ app.service('CalendarFactory', function($window, DavClient, Calendar, WebCal, co
 			const index = owner.indexOf('/remote.php/dav/principals/users/');
 			if (index !== -1) {
 				// '/remote.php/dav/principals/users/'.length === 33
-				return owner.substr(index + 33);
+				return owner.slice(index + 33);
 			}
 		}
 
@@ -148,9 +148,9 @@ app.service('CalendarFactory', function($window, DavClient, Calendar, WebCal, co
 			let displayName = share.getElementsByTagNameNS(DavClient.NS_OWNCLOUD, 'common-name');
 			if (displayName.length === 0) {
 				if (href.startsWith(SHARE_USER_PREFIX)) {
-					displayName = href.substr(SHARE_USER_PREFIX.length);
+					displayName = href.slice(SHARE_USER_PREFIX.length);
 				} else {
-					displayName = href.substr(SHARE_GROUP_PREFIX.length);
+					displayName = href.slice(SHARE_GROUP_PREFIX.length);
 				}
 			} else {
 				displayName = displayName[0].textContent;
@@ -166,21 +166,21 @@ app.service('CalendarFactory', function($window, DavClient, Calendar, WebCal, co
 			writable = writable.length !== 0;
 
 			if (href.startsWith(SHARE_USER_PREFIX)) {
-				if (href.substr(SHARE_USER_PREFIX.length) === owner) {
+				if (href.slice(SHARE_USER_PREFIX.length) === owner) {
 					// don't overwrite already present displayname
 					if (!ownerDisplayname) {
 						ownerDisplayname = displayName;
 					}
 				} else {
 					shares.users.push({
-						id: href.substr(SHARE_USER_PREFIX.length),
+						id: href.slice(SHARE_USER_PREFIX.length),
 						displayname: displayName,
 						writable: writable
 					});
 				}
 			} else if (href.startsWith(SHARE_GROUP_PREFIX)) {
 				shares.groups.push({
-					id: href.substr(SHARE_GROUP_PREFIX.length),
+					id: href.slice(SHARE_GROUP_PREFIX.length),
 					displayname: displayName,
 					writable: writable
 				});
@@ -219,12 +219,12 @@ app.service('CalendarFactory', function($window, DavClient, Calendar, WebCal, co
 		if (angular.isDefined(props['{' + DavClient.NS_CALENDARSERVER + '}publish-url'])) {
 			published = true;
 			let publishURL = props['{' + DavClient.NS_CALENDARSERVER + '}publish-url'][0].textContent;
-			if (publishURL.substr(-1) === '/') {
-				publishURL = publishURL.substr(0, publishURL.length - 1);
+			if (publishURL.slice(-1) === '/') {
+				publishURL = publishURL.slice(0, -1);
 			}
 
 			const lastIndexOfSlash = publishURL.lastIndexOf('/');
-			publicToken = publishURL.substr(lastIndexOfSlash + 1);
+			publicToken = publishURL.slice(lastIndexOfSlash + 1);
 		}
 
 		return [published, publicToken];
@@ -299,7 +299,7 @@ app.service('CalendarFactory', function($window, DavClient, Calendar, WebCal, co
 		}
 
 		const slashIndex = userPrincipal.lastIndexOf('/');
-		return userPrincipal.substr(slashIndex + 1);
+		return userPrincipal.slice(slashIndex + 1);
 	};
 
 	/**

--- a/js/app/filters/attendeefilter.js
+++ b/js/app/filters/attendeefilter.js
@@ -30,7 +30,7 @@ app.filter('attendeeFilter', function() {
 		} else if (typeof attendee.parameters === 'object' && typeof attendee.parameters.cn === 'string') {
 			return attendee.parameters.cn;
 		} else if (typeof attendee.value === 'string' && attendee.value.startsWith('MAILTO:')) {
-			return attendee.value.substr(7);
+			return attendee.value.slice(7);
 		} else {
 			return attendee.value || '';
 		}

--- a/js/app/models/calendarListItemModel.js
+++ b/js/app/models/calendarListItemModel.js
@@ -181,7 +181,7 @@ app.factory('CalendarListItem', function($rootScope, $window, Calendar, WebCal, 
 			const searchFor = '(' + context.calendar.owner + ')';
 			const lastIndexOf = context.calendar.displayname.lastIndexOf(searchFor);
 
-			return context.calendar.displayname.substr(0, lastIndexOf - 1);
+			return context.calendar.displayname.slice(0, lastIndexOf > 0 ? lastIndexOf - 1 : 0);
 		};
 
 		//Properties for ng-model of calendar editor

--- a/js/app/models/veventModel.js
+++ b/js/app/models/veventModel.js
@@ -329,7 +329,7 @@ app.factory('VEvent', function(TimezoneService, FcEvent, SimpleEvent, ICalFactor
 			var dateType = /[^:]*/.exec(el)[0];
 			var icsDate = null;
 
-			if (findTypes.indexOf(dateType) >= 0 && el.trim().substr(-3) === 'T::') { // is date without time
+			if (findTypes.indexOf(dateType) >= 0 && el.trim().slice(-3) === 'T::') { // is date without time
 				icsDate = el.replace(/[^0-9]/g, '');
 				ics = ics.replace(el, dateType + ';VALUE=DATE:' + icsDate);
 			}

--- a/js/app/service/davClient.js
+++ b/js/app/service/davClient.js
@@ -49,7 +49,7 @@ app.service('DavClient', function($window) {
 	 * @returns {string}
 	 */
 	client.buildUrl = function(path) {
-		if (path.substr(0,1) !== '/') {
+		if (path.slice(0,1) !== '/') {
 			path = '/' + path;
 		}
 

--- a/js/app/service/hashService.js
+++ b/js/app/service/hashService.js
@@ -36,10 +36,10 @@ app.service('HashService', function ($location) {
 		}
 
 		if (hash.startsWith('#')) {
-			hash = hash.substr(1);
+			hash = hash.slice(1);
 		}
 		if (hash.startsWith('/')) {
-			hash = hash.substr(1);
+			hash = hash.slice(1);
 		}
 
 
@@ -57,9 +57,9 @@ app.service('HashService', function ($location) {
 		}
 
 		const questionMarkPosition = hash.indexOf('?');
-		context.hashId = hash.substr(0, questionMarkPosition);
+		context.hashId = hash.slice(0, questionMarkPosition !== -1 ? questionMarkPosition : 0);
 
-		const parameters = hash.substr(questionMarkPosition + 1);
+		const parameters = hash.slice(questionMarkPosition + 1);
 		parameters.split('&').forEach((part) => {
 			const [key, value] = part.split('=');
 			context.parameters.set(key, decodeURIComponent(value));

--- a/js/app/service/veventService.js
+++ b/js/app/service/veventService.js
@@ -112,7 +112,7 @@ app.service('VEventService', function(DavClient, StringUtility, XMLUtility, VEve
 				const props = obj.propStat[0].properties;
 				const calendarData = props[context.calendarDataPropName];
 				const etag = props[context.eTagPropName];
-				const uri = obj.href.substr(obj.href.lastIndexOf('/') + 1);
+				const uri = obj.href.slice(obj.href.lastIndexOf('/') + 1);
 
 				try {
 					const vevent = VEvent.fromRawICS(calendar, calendarData, uri, etag);

--- a/js/app/utility/colorUtility.js
+++ b/js/app/utility/colorUtility.js
@@ -76,9 +76,9 @@ app.service('ColorUtility', function() {
 				var regex = new RegExp('^#([0-9a-f]{' + (colorString.length - 1) + '})$', 'i');
 				matchedString = colorString.match(regex);
 				return (Array.isArray(matchedString) && matchedString[1]) ? {
-					r: parseInt(matchedString[1].substr(0, 2), 16),
-					g: parseInt(matchedString[1].substr(2, 2), 16),
-					b: parseInt(matchedString[1].substr(4, 2), 16)
+					r: parseInt(matchedString[1].slice(0, 2), 16),
+					g: parseInt(matchedString[1].slice(2, 4), 16),
+					b: parseInt(matchedString[1].slice(4, 6), 16)
 				} : fallbackColor;
 
 			default:

--- a/js/app/utility/stringUtility.js
+++ b/js/app/utility/stringUtility.js
@@ -32,8 +32,8 @@ app.service('StringUtility', function () {
 			suffix = '.' + suffix;
 		}
 
-		return prefix + Math.random().toString(36).substr(2).toUpperCase() +
-			Math.random().toString(36).substr(2).toUpperCase() + suffix;
+		return prefix + Math.random().toString(36).slice(2).toUpperCase() +
+			Math.random().toString(36).slice(2).toUpperCase() + suffix;
 	};
 
 	this.uri = function(start, isAvailable) {
@@ -64,8 +64,8 @@ app.service('StringUtility', function () {
 		// === false because !undefined = true, possible infinite loop
 		do {
 			var positionLastDash = uri.lastIndexOf('-');
-			var firstPart = uri.substr(0, positionLastDash);
-			var lastPart = uri.substr(positionLastDash + 1);
+			var firstPart = uri.slice(0, positionLastDash !== -1 ? positionLastDash : 0);
+			var lastPart = uri.slice(positionLastDash + 1);
 
 			if (lastPart.match(/^\d+$/)) {
 				lastPart = parseInt(lastPart);

--- a/js/app/utility/webcalUtility.js
+++ b/js/app/utility/webcalUtility.js
@@ -57,7 +57,7 @@ app.service('WebCalUtility', function($rootScope) {
 	 */
 	this.downgradeURL = function(url) {
 		if (url.startsWith('https://')) {
-			return 'http://' + url.substr(8);
+			return 'http://' + url.slice(8);
 		}
 	};
 
@@ -70,7 +70,7 @@ app.service('WebCalUtility', function($rootScope) {
 		if (url.startsWith('http://') || url.startsWith('https://')) {
 			return url;
 		} else if (url.startsWith('webcal://')) {
-			return 'https://' + url.substr(9);
+			return 'https://' + url.slice(9);
 		} else {
 			return 'https://' + url;
 		}

--- a/tests/js/unit/models/simpleEventModelSpec.js
+++ b/tests/js/unit/models/simpleEventModelSpec.js
@@ -1553,9 +1553,9 @@ END:VCALENDAR`;
 
 		const simple = SimpleEvent(event);
 
-		expect(simple.dtstart.value.toString().substr(0, 24)).toEqual('Tue Oct 04 2016 09:00:00');
+		expect(simple.dtstart.value.toString().slice(0, 24)).toEqual('Tue Oct 04 2016 09:00:00');
 		delete simple.dtstart.value;
-		expect(simple.dtend.value.toString().substr(0, 24)).toEqual('Tue Oct 04 2016 11:30:00');
+		expect(simple.dtend.value.toString().slice(0, 24)).toEqual('Tue Oct 04 2016 11:30:00');
 		delete simple.dtend.value;
 
 		expect(simple.dtstart).toEqual({
@@ -1593,9 +1593,9 @@ END:VCALENDAR`;
 
 		const simple = SimpleEvent(event);
 
-		expect(simple.dtstart.value.toString().substr(0, 24)).toEqual('Sun Sep 25 2016 00:00:00');
+		expect(simple.dtstart.value.toString().slice(0, 24)).toEqual('Sun Sep 25 2016 00:00:00');
 		delete simple.dtstart.value;
-		expect(simple.dtend.value.toString().substr(0, 24)).toEqual('Mon Oct 10 2016 05:00:00');
+		expect(simple.dtend.value.toString().slice(0, 24)).toEqual('Mon Oct 10 2016 05:00:00');
 		delete simple.dtend.value;
 
 		expect(simple.dtstart).toEqual({
@@ -1632,9 +1632,9 @@ END:VCALENDAR`;
 
 		const simple = SimpleEvent(event);
 
-		expect(simple.dtstart.value.toString().substr(0, 24)).toEqual('Sat Nov 05 2016 23:59:00');
+		expect(simple.dtstart.value.toString().slice(0, 24)).toEqual('Sat Nov 05 2016 23:59:00');
 		delete simple.dtstart.value;
-		expect(simple.dtend.value.toString().substr(0, 24)).toEqual('Sat Nov 05 2016 23:59:00');
+		expect(simple.dtend.value.toString().slice(0, 24)).toEqual('Sat Nov 05 2016 23:59:00');
 		delete simple.dtend.value;
 
 		expect(simple.dtstart).toEqual({
@@ -1671,9 +1671,9 @@ END:VCALENDAR`;
 
 		const simple = SimpleEvent(event);
 
-		expect(simple.dtstart.value.toString().substr(0, 24)).toEqual('Tue Sep 27 2016 00:00:00');
+		expect(simple.dtstart.value.toString().slice(0, 24)).toEqual('Tue Sep 27 2016 00:00:00');
 		delete simple.dtstart.value;
-		expect(simple.dtend.value.toString().substr(0, 24)).toEqual('Wed Sep 28 2016 00:00:00');
+		expect(simple.dtend.value.toString().slice(0, 24)).toEqual('Wed Sep 28 2016 00:00:00');
 		delete simple.dtend.value;
 
 		expect(simple.dtstart).toEqual({


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.