### PR TITLE
feat: php8 support

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -4,7 +4,7 @@ MINIO_MC = "minio/mc:RELEASE.2020-12-18T10-53-53Z"
 OC_CI_ALPINE = "owncloudci/alpine:latest"
 OC_CI_BAZEL_BUILDIFIER = "owncloudci/bazel-buildifier"
 OC_CI_CEPH = "owncloudci/ceph:tag-build-master-jewel-ubuntu-16.04"
-OC_CI_CORE = "owncloudci/core"
+OC_CI_CORE = "owncloudci/core:php83"
 OC_CI_DRONE_SKIP_PIPELINE = "owncloudci/drone-skip-pipeline"
 OC_CI_NODEJS = "owncloudci/nodejs:%s"
 OC_CI_ORACLE_XE = "owncloudci/oracle-xe:latest"
@@ -21,7 +21,7 @@ SELENIUM_STANDALONE_CHROME_DEBUG = "selenium/standalone-chrome-debug:3.141.59-ox
 SELENIUM_STANDALONE_FIREFOX_DEBUG = "selenium/standalone-firefox-debug:3.8.1"
 SONARSOURCE_SONAR_SCANNER_CLI = "sonarsource/sonar-scanner-cli"
 
-DEFAULT_PHP_VERSION = "7.4"
+DEFAULT_PHP_VERSION = "8.3"
 DEFAULT_NODEJS_VERSION = "14"
 
 # minio mc environment variables
@@ -53,7 +53,7 @@ config = {
     "branches": [
         "master",
     ],
-    "codestyle": True,
+    "codestyle": False,
     "javascript": {
         "extraCommandsBeforeTestRun": [
             "apt update -y",
@@ -63,7 +63,7 @@ config = {
             "apt-get install firefox -y",
         ],
     },
-    "phpunit": True,
+    "phpunit": False,
 }
 
 def main(ctx):

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  APP_NAME: calendar
+  PHP_VERSIONS: '["8.3"]'
+
+jobs:
+  get-vars:
+    runs-on: ubuntu-latest
+    outputs:
+      app-name: ${{ env.APP_NAME }}
+      php-versions: ${{ env.PHP_VERSIONS }}
+    steps:
+      - name: Set variables
+        run: |
+          echo "App name $APP_NAME"
+          echo "PHP versions string: $PHP_VERSIONS"
+
+  semantic-git-messages:
+    name: Commits
+    uses: owncloud/reusable-workflows/.github/workflows/semantic-git-message.yml@main
+
+  php-code-style:
+    name: PHP Code Style
+    needs:
+      - get-vars
+    uses: owncloud/reusable-workflows/.github/workflows/php-codestyle.yml@main
+    with:
+      app-name: ${{ needs.get-vars.outputs.app-name }}
+      php-versions: ${{ needs.get-vars.outputs.php-versions }}
+      disable-phpstan: true
+      disable-phan: true
+
+  php-unit:
+    name: PHP Unit
+    needs:
+      - get-vars
+    uses: owncloud/reusable-workflows/.github/workflows/php-unit.yml@main
+    with:
+      app-name: ${{ needs.get-vars.outputs.app-name }}
+      php-versions: ${{ needs.get-vars.outputs.php-versions }}

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,11 +9,12 @@
 * **WebCal Support!** Want to see your favorite team’s matchdays in your calendar? No problem!
 * **Attendees!** Invite people to your events.
 </description>
-	<version>2.0.0</version>
+	<version>2.1.0</version>
 	<licence>AGPL</licence>
 	<author>Georg Ehrke, Raghu Nayyar, Bernhard Fröhler, Julian Müller</author>
 	<dependencies>
-		<owncloud min-version="10.11" max-version="10" />
+		<owncloud min-version="11" max-version="11" />
+		<php min-version="8.3" />
 	</dependencies>
 	<documentation>
 		<user>https://doc.owncloud.com/webui/next/classic_ui/pim/</user>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "owncloud/calendar",
   "config" : {
     "platform": {
-      "php": "7.3"
+      "php": "8.3"
     },
     "allow-plugins": {
       "bamarni/composer-bin-plugin": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a11541f24ef060ed1480ee1f0cfaa656",
+    "content-hash": "6ec2596b744d6e1f01d4bb749d752cf6",
     "packages": [],
     "packages-dev": [
         {
             "name": "bamarni/composer-bin-plugin",
-            "version": "1.8.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bamarni/composer-bin-plugin.git",
-                "reference": "24764700027bcd3cb072e5f8005d4a150fe714fe"
+                "reference": "641d0663f5ac270b1aeec4337b7856f76204df47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/24764700027bcd3cb072e5f8005d4a150fe714fe",
-                "reference": "24764700027bcd3cb072e5f8005d4a150fe714fe",
+                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/641d0663f5ac270b1aeec4337b7856f76204df47",
+                "reference": "641d0663f5ac270b1aeec4337b7856f76204df47",
                 "shasum": ""
             },
             "require": {
@@ -26,15 +26,15 @@
                 "php": "^7.2.5 || ^8.0"
             },
             "require-dev": {
-                "composer/composer": "^2.0",
+                "composer/composer": "^2.2.26",
                 "ext-json": "*",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpunit/phpunit": "^8.5 || ^9.5",
-                "symfony/console": "^5.4.7 || ^6.0.7",
-                "symfony/finder": "^5.4.7 || ^6.0.7",
-                "symfony/process": "^5.4.7 || ^6.0.7"
+                "phpstan/phpstan": "^1.8 || ^2.0",
+                "phpstan/phpstan-phpunit": "^1.1 || ^2.0",
+                "phpunit/phpunit": "^8.5 || ^9.6 || ^10.0",
+                "symfony/console": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+                "symfony/finder": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+                "symfony/process": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -60,20 +60,20 @@
             ],
             "support": {
                 "issues": "https://github.com/bamarni/composer-bin-plugin/issues",
-                "source": "https://github.com/bamarni/composer-bin-plugin/tree/1.8.0"
+                "source": "https://github.com/bamarni/composer-bin-plugin/tree/1.9.1"
             },
-            "time": "2022-07-14T10:29:51+00:00"
+            "time": "2026-02-04T10:18:12+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
-        "php": "7.3"
+        "php": "8.3"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/controller/viewcontroller.php
+++ b/controller/viewcontroller.php
@@ -208,7 +208,6 @@ class ViewController extends Controller {
 		$appVersion = $this->config->getAppValue($this->appName, 'installed_version');
 		$webCalWorkaround = $runningOnServer91OrLater ? 'no' : 'yes';
 		$isIE = $this->request->isUserAgent([Request::USER_AGENT_IE]);
-//		$defaultColor = $this->config->getAppValue('theming', 'color', '#1d2d44');
 		$canSharePublicLink = $this->config->getAppValue('core', 'shareapi_allow_links', 'yes');
 
 		return [

--- a/tests/unit/controller/viewcontrollerTest.php
+++ b/tests/unit/controller/viewcontrollerTest.php
@@ -256,28 +256,6 @@ class ViewControllerTest extends \PHPUnit\Framework\TestCase {
 		$this->request->expects($this->once())
 			->method('isUserAgent')
 			->willReturn(false);
-//		$actual = $this->controller->index();
-//
-//		$this->assertInstanceOf('OCP\AppFramework\Http\TemplateResponse', $actual);
-//		$this->assertEquals([
-//			'appVersion' => '42.13.37',
-//			'initialView' => 'someView',
-//			'emailAddress' => 'test@bla.com',
-//			'skipPopover' => 'someSkipPopoverValue',
-//			'weekNumbers' => 'someShowWeekNrValue',
-//			'firstRun' => 'someFirstRunValue',
-//			'supportsClass' => $expectsSupportsClass,
-//			'defaultColor' => '#1d2d44',
-//			'webCalWorkaround' => $expectsWebcalWorkaround,
-//			'isPublic' => false,
-//			'isEmbedded' => false,
-//			'isIE' => $isIE,
-//			'token' => '',
-//			'shareeCanEditShares' => 'no',
-//			'shareeCanEditCalendarProperties' => 'no',
-//			'canSharePublicLink' => 'yes'
-//		], $actual->getParams());
-//		$this->assertEquals('main', $actual->getTemplateName());
 
 		if ($expectsSetRequest) {
 			$this->config->expects($this->once())

--- a/vendor-bin/owncloud-codestyle/composer.json
+++ b/vendor-bin/owncloud-codestyle/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "owncloud/coding-standard": "^3.0"
+        "owncloud/coding-standard": "^5.3"
     }
 }


### PR DESCRIPTION
Js tests still run on drone because there is some setup required. In addition, there are no phpstan nor phan analysis at the moment, so those are disabled in the github workflow.