### PR TITLE
feat: publish a signed release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    uses: owncloud/reusable-workflows/.github/workflows/release.yml@main
+    with:
+      app-name: calendar
+      # calendar emits two tarballs both named calendar.tar.gz (source and
+      # appstore); publish only the appstore one, otherwise the release assets
+      # collide.
+      artifact-glob: build/artifacts/appstore/*.tar.gz
+    secrets:
+      SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+      SIGNING_CERT: ${{ secrets.SIGNING_CERT }}
+      SIGNING_CHAIN: ${{ secrets.SIGNING_CHAIN }}


### PR DESCRIPTION
## What

Adds a `Release` workflow: on a `v*` tag push, the app is built, signed, and the
tarball is attached to a GitHub Release. Delegates to
[`owncloud/reusable-workflows`](https://github.com/owncloud/reusable-workflows/blob/main/.github/workflows/release.yml),
matching every other classic app (`user_ldap`, `notes`, `activity`,
`files_texteditor`, `market`, `password_policy`, `files_antivirus`,
`files_pdfviewer`).

## Why

`make dist` in CI has been silently producing **unsigned** tarballs. `CAN_SIGN` is
only set when key, cert *and* `occ` all exist locally, so the `else` branch just
echoes a message and the build still exits 0 — confirmed in the latest `Build dist`
run:

```
Skipping signing, either no key and certificate found in
/home/runner/.owncloud/certificates/calendar.key and ... or occ can not be found
```

Signing is **mandatory on ownCloud 11+** — an unsigned app is blocked, not warned.
Signing now uses [`ocsign`](https://github.com/owncloud/ocsign), which needs no
ownCloud server, and the reusable workflow **asserts** the tarball carries a
schema-v2 `appinfo/signature.json` whose leaf `CN` matches the app id.

## Notes

`calendar` emits two tarballs both named `calendar.tar.gz` (source and appstore), so
`artifact-glob` pins the appstore one — the installable bundle with built
`css/public` + `js/public` — to avoid a release asset collision. Same resolution
`notes` used for the identical case.

The workflow also requires the pushed tag (minus the leading `v`) to equal
`<version>` in `appinfo/info.xml`.

## Before this can publish

- `SIGNING_KEY`, `SIGNING_CERT` and `SIGNING_CHAIN` must be set on this repository.
  G2 enrollment is in flight (`owncloud/developer-certificates#76`). Without them the
  release job fails fast with a clear message rather than shipping something
  unsigned.
- #1367 must land — the `appstore` target's `occ` config shuffle fails in CI, where
  `../../config` does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
