### PR TITLE
chore: prepare release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased] - XXXX-XX-XX
 
+
+## [2.1.0] - 2026-08-02
+
+### Changed
+
+- [#1341](https://github.com/owncloud/calendar/pull/1341) - Add PHP 8.3 support
+- This version requires ownCloud 11 and PHP 8.3
+
 ### Fixed
 
 - Prevent abuse of the public calendar "send mail" endpoint for phishing by
   escaping the calendar name/user name in the mail body and generating the
   public link on the server from the sharing token instead of accepting a
   caller-supplied URL (OC10-123)
+- [#1242](https://github.com/owncloud/calendar/pull/1242) - Replace the deprecated `String.prototype.substr()`
 
 
 ## [2.0.0] - 2022-07-05
@@ -235,7 +244,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Adjusted colors to Nextcloud
 - Properly display line breaks in agenda views
 
-[Unreleased]: https://github.com/owncloud/calendar/compare/v2.0.0...master
+[Unreleased]: https://github.com/owncloud/calendar/compare/v2.1.0...master
+[2.1.0]: https://github.com/owncloud/calendar/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/owncloud/calendar/compare/v1.6.4...v2.0.0
 [1.6.4]: https://github.com/owncloud/calendar/compare/v1.6.3...v1.6.4
 [1.6.3]: https://github.com/owncloud/calendar/compare/v1.6.2...v1.6.3

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # Organization and project keys are displayed in the right sidebar of the project homepage
 sonar.organization=owncloud-1
 sonar.projectKey=owncloud_calendar
-sonar.projectVersion=2.0.0
+sonar.projectVersion=2.1.0
 sonar.host.url=https://sonarcloud.io
 
 # =====================================================


### PR DESCRIPTION
## What

Cuts 2.1.0, the first release since 2.0.0 (2023-07-28).

- `CHANGELOG.md`: `[Unreleased]` closed out as `[2.1.0] - 2026-08-02`, link refs updated
- `sonar-project.properties`: `sonar.projectVersion` 2.0.0 → 2.1.0

`appinfo/info.xml` needs **no change** — it already declares `2.1.0`, bumped in
7a3e1ef2 along with the `min-version`/`max-version` 11 dependency, but never tagged.

## What ships in 2.1.0

- PHP 8.3 support / ownCloud Classic 11 (#1341)
- The OC10-123 public-sendmail phishing hardening (#1363)
- Replacement of the deprecated `String.prototype.substr()` (#1242)
- ~120 dependency updates

## Depends on

- #1367 — `appstore` target's `occ` config shuffle breaks the release job in CI
- #1368 — the signed-release workflow itself

Once all three are on `master` and the `SIGNING_*` secrets are in place
(`owncloud/developer-certificates#76`), tagging `v2.1.0` builds, G2-signs and
publishes `calendar.tar.gz` automatically. The release workflow enforces that the
tag matches `<version>` in `appinfo/info.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
